### PR TITLE
Prevent sometimes incorrect assignment of dtype to name with fromhdf5

### DIFF
--- a/bcolz/ctable.py
+++ b/bcolz/ctable.py
@@ -670,7 +670,7 @@ class ctable(object):
         else:
             names = t.colnames
         # Collect metadata
-        dtypes = [dt[0] for dt in t.dtype.fields.values()]
+        dtypes = [t.dtype.fields[name][0] for name in names]
         cols = [np.zeros(0, dtype=dt) for dt in dtypes]
         # Create an empty ctable
         ct = ctable(cols, names, **kwargs)

--- a/bcolz/tests/test_ctable.py
+++ b/bcolz/tests/test_ctable.py
@@ -1638,6 +1638,7 @@ class conversionTest(TestCase):
         tmpfile = tempfile.mktemp(".h5")
         ct.tohdf5(tmpfile)
         ct2 = bcolz.ctable.fromhdf5(tmpfile)
+        self.assertEqual(ct.dtype, ct2.dtype)
         for key in ct.names:
             assert_allclose(ct2[key][:], ct[key][:])
         os.remove(tmpfile)


### PR DESCRIPTION
Using the values in tables dtype fields dictionary-like object results
in a sometimes mismatch between the ctable's column name and expected
dtype, because the ordering is not guaranteed.

Instead, look up dtype for each column name in the same ordering that
the names that are passed to the ctable initialization.

This was noticed when a table that had been created from a DataFrame using, `bcolz.ctable.fromdataframe(df).tohdf5('foo.h5')`, was read back with `bcolz.ctable.fromhdf5('foo.h5')` and what was written to the disk as a `<f8` was being read back as an `<i8` with the mantissas truncated.

Had confirmed the writing of disk with the correct dtype with code:

```
import tables
foo = tables.open_file('foo.h5')
foo.get_node('/splits').read()
```

Which returned the output below, in which the field 'a' was a float as intended, but which were sometimes read back as integers when using `ctable.fromhdf5`

```
array([(0.8, 1009929600000000000, 1009929600000000000, 1),
       (0.6, 1009929600000000000, 1009929600000000000, 2),
       (0.5, 1009929600000000000, 1009929600000000000, 3), ...,
       (0.3, 1406592000000000000, 1406592000000000000, 4),
       (10.0, 1407110400000000000, 1406851200000000000, 5),
       (0.7, 1407196800000000000, 1407196800000000000, 6)], 
      dtype=[('a', '<f8'), ('b', '<i8'), ('c', '<i8'), ('d', '<i8')])
```
