### PR TITLE
Close file handle when nodepath arg to ctable.fromhdf5 is incorrect.

### DIFF
--- a/bcolz/ctable.py
+++ b/bcolz/ctable.py
@@ -661,7 +661,12 @@ class ctable(object):
 
         # Read the Table on file
         f = tb.open_file(filepath)
-        t = f.get_node(nodepath)
+        try:
+            t = f.get_node(nodepath)
+        except:
+            f.close()
+            raise
+
         # Use the names in kwargs, or if not there, the names in Table
         if 'names' in kwargs:
             names = kwargs.pop('names')


### PR DESCRIPTION
Close the tables file before re-raising the exception that occurs during
node retrieval to prevent leaking file handles.

Catch all exceptions so that NoSuchNodeErrors, ValueErrors and other
errors are all handled.Close the tables file before raising a NoSuchNodeError to prevent

---

Discovered this when in a REPL within in an environment with a STRICT open file policy.
If the given nodepath was incorrect, it is not possible to re-run the fromhdf5 command with a different nodepath since the tables file handle was left open.

Closing the file before raising the NoSuchNodeError allows the fromhdf5 to be re-attempted.

Example output with the patch applied:

```
In [1]: tables.file._FILE_OPEN_POLICY = 'strict'
In [2]: import bcolz
In [3]: bcolz.ctable.fromhdf5('foo.h5', nodepath='/bar')
...
NoSuchNodeError: group ``/`` does not have a child named ``/bar``
in [4]: bcolz.ctable.fromhdf5('foo.h5', nodepath='/correctpath')
...
ValueError: The file 'foo.h5' is already opened.  Please close it before reopening.  HDF5 v.1.8.11, FILE_OPEN_POLICY = 'strict'
```

With the patch applied:

```
In [1]: tables.file._FILE_OPEN_POLICY = 'strict'
In [2]: import bcolz
In [3]: bcolz.ctable.fromhdf5('foo.h5', nodepath='/bar')
...
NoSuchNodeError: group ``/`` does not have a child named ``/bar``
in [4]: bcolz.ctable.fromhdf5('foo.h5', nodepath='/correctpath')
...
ctable((1333185,), [('a', '<u4'), ('b', '<u4'), ('c', '<u4')])
  nbytes: 35.60 MB; cbytes: 16.73 MB; ratio: 2.13
  cparams := cparams(clevel=5, shuffle=True, cname='blosclz')
....
```
