### PR TITLE
use __dealloc__ instead of __del__

### DIFF
--- a/bcolz/carray_ext.pyx
+++ b/bcolz/carray_ext.pyx
@@ -2583,11 +2583,9 @@ cdef class carray:
         # Finally, update the sizes metadata on-disk
         self._update_disk_sizes()
 
-    # XXX This does not work.  Will have to realize how to properly
-    # flush buffers before self going away...
-    # def __del__(self):
-    #   # Make a flush to disk if this object get disposed
-    #   self.flush()
+    # for cython classes use __dealloc__ instead of __del__
+    def __dealloc__(self):
+        self.flush()
 
     def __str__(self):
         return array2string(self)


### PR DESCRIPTION
As stated in:

http://docs.cython.org/src/userguide/special_methods.html#finalization-method-dealloc

""" The counterpart to the __cinit__() method is the __dealloc__() method,
which should perform the inverse of the __cinit__() method. Any C data that
you explicitly allocated (e.g. via malloc) in your __cinit__() method should
be freed in your __dealloc__() method.

You need to be careful what you do in a __dealloc__() method. By the time
your
__dealloc__() method is called, the object may already have been partially 
destroyed and may not be in a valid state as far as Python is concerned, so
you should avoid invoking any Python operations which might touch the object.
In particular, don’t call any other methods of the object or do anything
which might cause the object to be resurrected. It’s best if you stick to
just deallocating C data.

You don’t need to worry about deallocating Python attributes of your object, 
because that will be done for you by Cython after your __dealloc__() method 
returns.

When subclassing extension types, be aware that the __dealloc__() method of
the superclass will always be called, even if it is overridden. This is in
contrast to typical Python behavior where superclass methods will not be
executed unless they are explicitly called by the subclass.

Note

There is no __del__() method for extension types.
"""

Although it does say not to call any other methods of the object, it did work 
for me(™) in a simple example.... Not sure.