### PR TITLE
carray_ext.pxd

### DIFF
--- a/bcolz/carray_ext.pxd
+++ b/bcolz/carray_ext.pxd
@@ -1,0 +1,60 @@
+import numpy as np
+
+from definitions cimport ndarray, dtype, npy_intp
+
+ctypedef ndarray ndarray_t
+
+cdef class chunk:
+    cdef char typekind, isconstant
+    cdef public int atomsize, itemsize, blocksize
+    cdef public int nbytes, cbytes, cdbytes
+    cdef int true_count
+    cdef char *data
+    cdef object atom, constant, dobject
+
+    cdef void _getitem(self, int start, int stop, char *dest)
+    cdef compress_data(self, char *data, size_t itemsize, size_t nbytes,
+                       object cparams)
+    cdef compress_arrdata(self, ndarray array, int itemsize,
+                          object cparams, object _memory)
+
+
+cdef class chunks(object):
+    cdef object _rootdir, _mode
+    cdef object dtype, cparams, lastchunkarr
+    cdef object chunk_cached
+    cdef npy_intp nchunks, nchunk_cached, len
+
+    cdef read_chunk(self, nchunk)
+    cdef _save(self, nchunk, chunk_)
+
+cdef class carray:
+    cdef public int itemsize, atomsize
+    cdef int _chunksize, _chunklen, leftover
+    cdef int nrowsinbuf, _row
+    cdef int sss_mode, wheretrue_mode, where_mode
+    cdef npy_intp startb, stopb
+    cdef npy_intp start, stop, step, nextelement
+    cdef npy_intp _nrow, nrowsread
+    cdef npy_intp _nbytes, _cbytes
+    cdef npy_intp nhits, limit, skip
+    cdef npy_intp expectedlen
+    cdef char *lastchunk
+    cdef object lastchunkarr, where_arr, arr1
+    cdef object _cparams, _dflt
+    cdef object _dtype
+    cdef public object chunks
+    cdef object _rootdir, datadir, metadir, _mode
+    cdef object _attrs, iter_exhausted
+    cdef ndarray iobuf, where_buf
+    # For block cache
+    cdef int idxcache
+    cdef ndarray blockcache
+    cdef char *datacache
+
+    cdef void bool_update(self, boolarr, value)
+    cdef int getitem_cache(self, npy_intp pos, char *dest)
+    cdef reset_iter_sentinels(self)
+    cdef int check_zeros(self, object barr)
+    cdef _adapt_dtype(self, dtype_, shape)
+

--- a/bcolz/carray_ext.pyx
+++ b/bcolz/carray_ext.pyx
@@ -283,18 +283,6 @@ cdef class chunk:
     This class is meant to be used only by the `carray` class.
 
     """
-    cdef char typekind, isconstant
-    cdef public int atomsize, itemsize, blocksize
-    cdef public int nbytes, cbytes, cdbytes
-    cdef int true_count
-    cdef char *data
-    cdef object atom, constant, dobject
-
-    cdef void _getitem(self, int start, int stop, char *dest)
-    cdef compress_data(self, char *data, size_t itemsize, size_t nbytes,
-                       object cparams)
-    cdef compress_arrdata(self, ndarray array, int itemsize,
-                          object cparams, object _memory)
 
     property dtype:
         "The NumPy dtype for this chunk."
@@ -353,7 +341,7 @@ cdef class chunk:
         self.cdbytes = cbytes
         self.blocksize = blocksize
 
-    cdef compress_arrdata(self, ndarray array, int itemsize,
+    cdef compress_arrdata(self, ndarray_t array, int itemsize,
                           object cparams, object _memory):
         """Compress data in `array` and put it in ``self.data``"""
         cdef size_t nbytes, cbytes, blocksize, footprint
@@ -653,11 +641,6 @@ cdef decode_blosc_header(buffer_):
 
 cdef class chunks(object):
     """Store the different carray chunks in a directory on-disk."""
-    cdef object _rootdir, _mode
-    cdef object dtype, cparams, lastchunkarr
-    cdef object chunk_cached
-    cdef npy_intp nchunks, nchunk_cached, len
-
     property mode:
         "The mode used to create/open the `mode`."
         def __get__(self):
@@ -859,29 +842,6 @@ cdef class carray:
 
     """
 
-    cdef public int itemsize, atomsize
-    cdef int _chunksize, _chunklen, leftover
-    cdef int nrowsinbuf, _row
-    cdef int sss_mode, wheretrue_mode, where_mode
-    cdef npy_intp startb, stopb
-    cdef npy_intp start, stop, step, nextelement
-    cdef npy_intp _nrow, nrowsread
-    cdef npy_intp _nbytes, _cbytes
-    cdef npy_intp nhits, limit, skip
-    cdef npy_intp expectedlen
-    cdef char *lastchunk
-    cdef object lastchunkarr, where_arr, arr1
-    cdef object _cparams, _dflt
-    cdef object _dtype
-    cdef public object chunks
-    cdef object _rootdir, datadir, metadir, _mode
-    cdef object _attrs, iter_exhausted
-    cdef ndarray iobuf, where_buf
-    # For block cache
-    cdef int idxcache
-    cdef ndarray blockcache
-    cdef char *datacache
-
     property leftovers:
         def __get__(self):
             # Pointer to the leftovers chunk
@@ -1018,17 +978,17 @@ cdef class carray:
         self.where_mode = False
         self.idxcache = -1  # cache not initialized
 
-    cdef _adapt_dtype(self, dtype, shape):
+    cdef _adapt_dtype(self, dtype_, shape):
         """adapt the dtype to one supported in carray.
         returns the adapted type with the shape modified accordingly.
         """
-        if dtype.hasobject:
-            if dtype != np.object_:
-                raise TypeError(repr(dtype) + " is not a supported dtype")
+        if dtype_.hasobject:
+            if dtype_ != np.object_:
+                raise TypeError(repr(dtype_) + " is not a supported dtype")
         else:
-            dtype = np.dtype((dtype, shape[1:]))
+            dtype_ = np.dtype((dtype_, shape[1:]))
 
-        return dtype
+        return dtype_
 
     def create_carray(self, array, cparams, dtype, dflt,
                       expectedlen, chunklen, rootdir, mode):


### PR DESCRIPTION
Hi Valentin,

as previously discussed per mail, here is the carray_ext.pxd pull request.
To check everything was fine I compiled, reinstalled and ran python bcolz/tests/all.py.

I tried to make as less changes as possible, but I still have some doubts.

Refactoring dtype parameter in _adapt_dtype function, was done only to be on the safe side, but
I am not completely sure if it is strictly necessary.

These cimport ndarray, dtype, npy_intp can still be found in both files (pyx and pxd)

Looking forward to any suggestions and improvements you have.

Regards,
Francesc