### PR TITLE
Unicode handling for column addressing

### DIFF
--- a/bcolz/ctable.py
+++ b/bcolz/ctable.py
@@ -1085,7 +1085,7 @@ class ctable(object):
                 raise IndexError(
                     "arrays used as indices must be integer (or boolean)")
         # Column name or expression
-        elif type(key) is str:
+        elif isinstance(key, basestring):
             if key not in self.names:
                 # key is not a column name, try to evaluate
                 arr = self.eval(key, depth=4)


### PR DESCRIPTION
Hi,

addressing a column ct[col].rootdir with a unicode col string, generated an error like this: 

```
/srv/python/venv/local/lib/python2.7/site-packages/bcolz/ctable.pyc in __getitem__(self, key)
   1098         # All the rest not implemented
   1099         else:
-> 1100             raise NotImplementedError("key not supported: %s" % repr(key))
   1101 
   1102         # From now on, will only deal with [start:stop:step] slices

NotImplementedError: key not supported: u'o'
```

This solves that.
