### PR TITLE
python3 compat for pickle tests

### DIFF
--- a/bcolz/tests/test_carray.py
+++ b/bcolz/tests/test_carray.py
@@ -18,7 +18,7 @@ from bcolz.tests import common
 from bcolz.tests.common import (
     MayBeDiskTest, TestCase, unittest, skipUnless, SkipTest)
 import bcolz
-from bcolz.py2help import xrange
+from bcolz.py2help import xrange, PY2
 from bcolz.carray_ext import chunk
 import pickle
 import os
@@ -67,7 +67,10 @@ class pickleTest(MayBeDiskTest, TestCase):
         a = np.arange(1e2)
         b = bcolz.carray(a, rootdir=self.rootdir)
         s = pickle.dumps(b)
-        self.assertEquals(type(s), str)
+        if PY2:
+            self.assertTrue(type(s), str)
+        else:
+            self.assertTrue(type(s), bytes)
 
         b2 = pickle.loads(s)
         self.assertEquals(b2.rootdir, b.rootdir)

--- a/bcolz/tests/test_ctable.py
+++ b/bcolz/tests/test_ctable.py
@@ -17,7 +17,7 @@ from numpy.testing import assert_array_equal, assert_allclose
 from bcolz.tests.common import (
     MayBeDiskTest, TestCase, unittest, skipUnless)
 import bcolz
-from bcolz.py2help import xrange
+from bcolz.py2help import xrange, PY2
 import pickle
 import os
 import shutil
@@ -1874,7 +1874,10 @@ class pickleTest(MayBeDiskTest, TestCase):
                          names=['a', 'b'],
                          rootdir=self.rootdir)
         s = pickle.dumps(b)
-        self.assertEquals(type(s), str)
+        if PY2:
+            self.assertTrue(type(s), str)
+        else:
+            self.assertTrue(type(s), bytes)
 
         b2 = pickle.loads(s)
         self.assertEquals(b2.rootdir, b.rootdir)


### PR DESCRIPTION
Closes #93

Not sure if this is the best approach, maybe doing an isinstance with the
string types would be better?
