### PR TITLE
Improve the release procedure

### DIFF
--- a/ANNOUNCE.rst
+++ b/ANNOUNCE.rst
@@ -10,7 +10,8 @@ What's new
 ``bcolz`` is a renaming of the ``carray`` project.  The new goals for
 the project are to create simple, yet flexible compressed containers,
 that can live either on-disk or in-memory, and with some
-high-performance iterators (like `iter()`, `where()`) for querying them.
+high-performance iterators (like ``iter()``, ``where()``) for querying
+them.
 
 Together, bcolz and the Blosc compressor, are finally fulfilling the
 promise of accelerating memory I/O, at least for some real scenarios:

--- a/ANNOUNCE.rst
+++ b/ANNOUNCE.rst
@@ -82,3 +82,4 @@ https://github.com/Blosc/bcolz/blob/master/LICENSES/BCOLZ.txt
 .. coding: utf-8
 .. fill-column: 72
 .. End:
+.. vim: set textwidth=72:

--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -5,6 +5,8 @@ Release notes for bcolz
 Changes from 0.7.3 to 0.7.4 (Coming soon)
 =========================================
 
+- Overhaul the release procedure
+
 - Other miscellaneous fixes and improvements
 
 Changes from 0.7.2 to 0.7.3

--- a/RELEASING.rst
+++ b/RELEASING.rst
@@ -119,7 +119,7 @@ Post-release actions
 * Edit ``VERSION`` in master to increment the version to the next
   minor one (i.e. X.Y.Z --> X.Y.(Z+1).dev).
 
-* Also, update the `version` and `release` variables in doc/conf.py.
+* Also, update the ``version`` and ``release`` variables in doc/conf.py.
 
 * Create new headers for adding new features in ``RELEASE_NOTES.rst``
   and empty the release-specific information in ``ANNOUNCE.rst`` and

--- a/RELEASING.rst
+++ b/RELEASING.rst
@@ -90,7 +90,11 @@ Tagging
 
     $ git tag -a vX.Y.Z -m "Tagging version X.Y.Z"
 
-* Push the tag to the Github repo (assuming origin is correct)::
+* Or, alternatively, make a signed tag (requires gpg correctly configured)::
+
+    $ git tag -s vX.Y.Z -m "Tagging version X.Y.Z"
+
+* Push the tag to the Github repo (assuming ``origin`` is correct)::
 
     $ git push origin vX.Y.Z
 

--- a/RELEASING.rst
+++ b/RELEASING.rst
@@ -107,10 +107,6 @@ Tagging
 Announcing
 ----------
 
-* Update the release notes in the bcolz site:
-
-  https://github.com/Blosc/bcolz/wiki/Release-Notes
-
 * Send an announcement to the bcolz, blosc, numpy, pandas and
   python-announce lists.  Use the ``ANNOUNCE.rst`` file as skeleton
   (or possibly as the definitive version).

--- a/RELEASING.rst
+++ b/RELEASING.rst
@@ -90,9 +90,9 @@ Tagging
 
     $ git tag -a vX.Y.Z -m "Tagging version X.Y.Z"
 
-* Push the tag to the github repo::
+* Push the tag to the Github repo (assuming origin is correct)::
 
-    $ git push --tags
+    $ git push origin vX.Y.Z
 
 
 Announcing

--- a/RELEASING.rst
+++ b/RELEASING.rst
@@ -66,6 +66,8 @@ Updating the online documentation site
 Packaging
 ---------
 
+* Check that all Cython generated ``*.c`` files are present.
+
 * Make the tarball with the command::
 
   $ python setup.py sdist

--- a/RELEASING.rst
+++ b/RELEASING.rst
@@ -34,6 +34,11 @@ Testing
 Updating the online documentation site
 --------------------------------------
 
+.. note::
+
+    This instructions are currently out-of-date and are to be considered under
+    construction.
+
 * Go to the doc directory::
 
   $ cd doc


### PR DESCRIPTION
Some obvious improvements of the relases procedure.

There are two items we should discuss in addition:

The deployment of the documentation may need to be tweaked a bit. I did set it
up to have the older docs available at:

http://bcolz.blosc.org/0.7.2/

I think this might be useful, maybe not.

Also, I don't see the value in duplicating the RELEASE_NOTES on in the wiki. In
fact I used a git clone of the wiki today and copied the release notes across
at the filesystem level.  During this I discovered, that the release notes on
the wiki had diverged(!):

https://github.com/Blosc/bcolz/wiki/Release-Notes/_compare/5d3bae0d80d8769609c4a2975f2f68a40cbfec44...ed33dff09b98ccb207a9c7e2ce68ba2d875e2dbe

If this is a good  change or not, I don't know... In any case it shows that
there is danger in duplicating the release notes to the wiki. I think people
could read them fine in the Github web interface, like so:

https://github.com/Blosc/bcolz/blob/v0.7.3/RELEASE_NOTES.rst