### PR TITLE
privatize get_git_description

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -5,7 +5,7 @@ Release notes for bcolz
 Changes from 0.7.3 to 0.7.4
 ===========================
 
-- pass
+- Other miscellaneous fixes and improvements
 
 Changes from 0.7.2 to 0.7.3
 ===========================

--- a/bcolz/__init__.py
+++ b/bcolz/__init__.py
@@ -72,7 +72,7 @@ except ImportError:
               "If on Python2.6 please install unittest2")
 
 
-def get_git_descrtiption(path_):
+def _get_git_descrtiption(path_):
     """ Get the output of git-describe when executed in a given path. """
 
     # imports in function because:
@@ -99,7 +99,7 @@ def get_git_descrtiption(path_):
     except subprocess.CalledProcessError:  # not in git repo
         pass
 
-git_description = get_git_descrtiption(__path__[0])
+git_description = _get_git_descrtiption(__path__[0])
 
 # Initialization code for the Blosc and numexpr libraries
 _blosc_init()


### PR DESCRIPTION
So that it doesn't show up when auto-completing with ipython.