### PR TITLE
Implement ``carray.purge``

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -5,7 +5,7 @@ Release notes for bcolz
 Changes from 0.8.1 to 0.9.0
 ===========================
 
-- pass
+- Implement ``purge``, which removes data for on-disk carrays. (#130 @esc)
 
 Changes from 0.8.0 to 0.8.1
 ===========================

--- a/bcolz/carray_ext.pyx
+++ b/bcolz/carray_ext.pyx
@@ -2566,6 +2566,11 @@ cdef class carray:
     #   # Make a flush to disk if this object get disposed
     #   self.flush()
 
+    def purge(self):
+        """ Remove the underlying data for on-disk arrays. """
+        if self.rootdir:
+            shutil.rmtree(self.rootdir)
+
     def __str__(self):
         return array2string(self)
 

--- a/bcolz/tests/test_carray.py
+++ b/bcolz/tests/test_carray.py
@@ -9,8 +9,10 @@
 
 from __future__ import absolute_import
 
+import os
 import sys
 import struct
+import shutil
 
 import numpy as np
 from numpy.testing import assert_array_equal, assert_allclose
@@ -2091,7 +2093,27 @@ class reprTest(TestCase):
         for el in x:
             self.assertTrue(el in result)
 
+class PurgeDiskArrayTest(MayBeDiskTest, TestCase):
+    disk = True
 
+    def test_purge(self):
+        b = bcolz.arange(1e2, rootdir=self.rootdir)
+        b.purge()
+        self.assertFalse(os.path.isdir(self.rootdir))
+
+    def test_purge_fails_for_missing_directory(self):
+        b = bcolz.arange(1e2, rootdir=self.rootdir)
+        shutil.rmtree(self.rootdir)
+        # OSError is fairly un-specific, but better than nothing
+        self.assertRaises(OSError, b.purge)
+
+class PurgeMemoryArrayTest(MayBeDiskTest, TestCase):
+    disk = False
+
+    def test_purge(self):
+        b = bcolz.arange(1e2, rootdir=self.rootdir)
+        # this should work and should be a noop
+        b.purge()
 
 if __name__ == '__main__':
     unittest.main(verbosity=2)


### PR DESCRIPTION
Purge was the best name I could think of, alternative suggestions welcome.