### PR TITLE
nleftover: the number of used elements in the leftover_array

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -5,7 +5,8 @@ Release notes for bcolz
 Changes from 0.8.0 to 0.8.1
 ===========================
 
-- pass
+- Implement ``nleftover`` which returns the number of leftover and uncompressed
+  elements.
 
 Changes from 0.7.3 to 0.8.0
 ===========================

--- a/bcolz/carray_ext.pyx
+++ b/bcolz/carray_ext.pyx
@@ -939,6 +939,11 @@ cdef class carray:
         def __get__(self):
             return self._nbytes
 
+    property nleftover:
+        "The number of leftover elements."
+        def __get__(self):
+            return cython.cdiv(self.leftover, self.atomsize)
+
     property ndim:
         "The number of dimensions of this object."
         def __get__(self):

--- a/bcolz/tests/test_carray.py
+++ b/bcolz/tests/test_carray.py
@@ -2092,6 +2092,20 @@ class reprTest(TestCase):
             self.assertTrue(el in result)
 
 
+class nleftoversTest(TestCase):
+
+    def test_empty(self):
+        a = carray([])
+        self.assertEquals(0, a.nleftover)
+
+    def test_one(self):
+        a = carray([1])
+        self.assertEqual(1, a.nleftover)
+
+    def test_beyond_one(self):
+        a = carray(np.zeros(2049), chunklen=2048)
+        self.assertEqual(1, a.nleftover)
+
 
 if __name__ == '__main__':
     unittest.main(verbosity=2)


### PR DESCRIPTION
Not sure about the the wording or if useful to others. I'd have liked to have
seen it when I initialize a small array and the length of the nchunks is zero.