### PR TITLE
Chunk iterator

### DIFF
--- a/bcolz/carray_ext.pxd
+++ b/bcolz/carray_ext.pxd
@@ -3,7 +3,9 @@ from numpy cimport ndarray, dtype, npy_intp
 cdef class chunk:
     cdef char typekind, isconstant
     cdef public int atomsize, itemsize, blocksize
-    cdef public int nbytes, cbytes, cdbytes
+    cdef public int nbytes, cbytes, cdbytes, _chunklen
+    cdef public int _iter_count
+    cdef public ndarray _iter_values
     cdef int true_count
     cdef char *data
     cdef object atom, constant, dobject

--- a/test_iter_chunk.py
+++ b/test_iter_chunk.py
@@ -1,0 +1,31 @@
+from contextlib import contextmanager
+import numpy as np
+import time
+from bcolz import carray
+from bcolz.carray_ext import test_v1, test_v2, test_v3
+
+@contextmanager
+def ctime(message=None):
+    assert message is not None
+    "Counts the time spent in some context"
+    t = time.time()
+    yield
+    print message + ":\t", \
+          round(time.time() - t, 4), "sec"
+
+n = 50033
+
+x = np.arange(0, n, 1)
+c = carray(x, dtype='int64', chunklen=100)
+
+with ctime('test_v1'):
+    r1 = test_v1(c)
+
+with ctime('test_v2'):
+    r2 = test_v2(c)
+
+with ctime('test_v3'):
+    r3 = test_v3(c)
+
+assert np.array_equal(r1, r2)
+assert np.array_equal(r1, r3)


### PR DESCRIPTION
Hi,

This PR tries to make possible to write the following cython code as described in  https://github.com/Blosc/bcolz/issues/73 by @esc ```for chunk_ in chunks:```

The PR contains two commits, the first one is the iterator's implementation itself and the second one a small test script

The test script which should not e part of the PR but I included it in case someone wants to run it 
```python test_iter_chunk.py``` gave the following results
```
test_v1:	1.768 sec
test_v2:	0.0008 sec
test_v3:	0.0034 sec
```
```for chunk_ in chunks:``` is around four times slower than the previous code written by Valentin.

Is this the right way to implement it? if yes does someone have any suggestion how this could be improved?

Thanks in advance for your time