### PR TITLE
Disk handling

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -5,7 +5,7 @@ Release notes for bcolz
 Changes from 0.8.0 to 0.8.1
 ===========================
 
-- pass
+- Implement ``purge``, which removes data for on-disk carrays. (@esc)
 
 Changes from 0.7.3 to 0.8.0
 ===========================

--- a/bcolz/carray_ext.pyx
+++ b/bcolz/carray_ext.pyx
@@ -2571,6 +2571,11 @@ cdef class carray:
     #   # Make a flush to disk if this object get disposed
     #   self.flush()
 
+    def purge(self):
+        """ Remove the underlying data for on-disk arrays. """
+        if self.rootdir:
+            shutil.rmtree(self.rootdir)
+
     def __str__(self):
         return array2string(self)
 

--- a/bcolz/carray_ext.pyx
+++ b/bcolz/carray_ext.pyx
@@ -315,12 +315,7 @@ cdef class chunk:
         self.atom = atom
         self.atomsize = atom.itemsize
         dtype_ = atom.base
-        # 'kind' isn't defined in the numpy.pxd
-        # kind is of type python str, typekind of type char
-        # in cython char is coerced to int
-        # kind[0] gives us the first character of the string
-        # ord gives us the ascii integer corresponding to that char
-        self.typekind = ord(dtype_.kind[0])
+        self.typekind = dtype_.kind
         # Hack for allowing strings with len > BLOSC_MAX_TYPESIZE
         if self.typekind == 'S':
             itemsize = 1

--- a/bcolz/ctable.py
+++ b/bcolz/ctable.py
@@ -460,7 +460,7 @@ class ctable(object):
 
         kwargs.setdefault('cparams', self.cparams)
 
-        if isinstance(newcol, np.ndarray):
+        if isinstance(newcol, (np.ndarray, bcolz.carray)):
             newcol = bcolz.carray(newcol, **kwargs)
         elif type(newcol) in (list, tuple):
             newcol = bcolz.carray(newcol, **kwargs)

--- a/bcolz/ctable.py
+++ b/bcolz/ctable.py
@@ -15,7 +15,6 @@ import itertools
 from collections import namedtuple
 import json
 import os
-import os.path
 import shutil
 from .py2help import _inttypes, _strtypes, imap, xrange
 
@@ -81,7 +80,7 @@ class cols(object):
         """Return the named column and remove it."""
         pos = self.names.index(name)
         name = self.names.pop(pos)
-        col = self._cols[name]
+        col = self._cols.pop(name)
         self.update_meta()
         return col
 
@@ -456,13 +455,14 @@ class ctable(object):
         if len(newcol) != self.len:
             raise ValueError("`newcol` must have the same length than ctable")
 
+        if self.rootdir is not None:
+            kwargs.setdefault('rootdir', os.path.join(self.rootdir, name))
+
+        kwargs.setdefault('cparams', self.cparams)
+
         if isinstance(newcol, np.ndarray):
-            if 'cparams' not in kwargs:
-                kwargs['cparams'] = self.cparams
             newcol = bcolz.carray(newcol, **kwargs)
         elif type(newcol) in (list, tuple):
-            if 'cparams' not in kwargs:
-                kwargs['cparams'] = self.cparams
             newcol = bcolz.carray(newcol, **kwargs)
         elif type(newcol) != bcolz.carray:
             raise ValueError(
@@ -516,7 +516,13 @@ class ctable(object):
             name = self.names[pos]
 
         # Remove the column
-        self.cols.pop(name)
+        col = self.cols.pop(name)
+
+        # remove the data if we have a rootdir
+        if self.rootdir is not None and col.rootdir is not None:
+            # is the col.rootdir is not None check necessary?
+            shutil.rmtree(os.path.join(self.rootdir, name))
+
         # Update _arr1
         self._arr1 = np.empty(shape=(1,), dtype=self.dtype)
 

--- a/bcolz/tests/test_carray.py
+++ b/bcolz/tests/test_carray.py
@@ -9,8 +9,10 @@
 
 from __future__ import absolute_import
 
+import os
 import sys
 import struct
+import shutil
 
 import numpy as np
 from numpy.testing import assert_array_equal, assert_allclose
@@ -2091,7 +2093,27 @@ class reprTest(TestCase):
         for el in x:
             self.assertTrue(el in result)
 
+class PurgeDiskArrayTest(MayBeDiskTest, TestCase):
+    disk = True
 
+    def test_purge(self):
+        b = bcolz.arange(1e2, rootdir=self.rootdir)
+        b.purge()
+        self.assertFalse(os.path.isdir(self.rootdir))
+
+    def test_purge_fails_for_missing_directory(self):
+        b = bcolz.arange(1e2, rootdir=self.rootdir)
+        shutil.rmtree(self.rootdir)
+        # OSError is fairly un-specific, but better than nothing
+        self.assertRaises(OSError, b.purge)
+
+class PurgeMemoryArrayTest(MayBeDiskTest, TestCase):
+    disk = False
+
+    def test_purge(self):
+        b = bcolz.arange(1e2, rootdir=self.rootdir)
+        # this should work and should be a noop
+        b.purge()
 
 if __name__ == '__main__':
     unittest.main(verbosity=2)

--- a/bcolz/tests/test_ctable.py
+++ b/bcolz/tests/test_ctable.py
@@ -14,13 +14,11 @@ import tempfile
 
 import numpy as np
 from numpy.testing import assert_array_equal, assert_allclose
-from bcolz.tests.common import (
-    MayBeDiskTest, TestCase, unittest, skipUnless)
+from bcolz.tests.common import MayBeDiskTest, TestCase, unittest, skipUnless
 import bcolz
 from bcolz.py2help import xrange, PY2
 import pickle
 import os
-import shutil
 
 
 class createTest(MayBeDiskTest):
@@ -379,6 +377,38 @@ class add_del_colMemoryTest(add_del_colTest, TestCase):
 
 class add_del_colDiskTest(add_del_colTest, TestCase):
     disk = True
+
+    def test_add_new_column_ondisk(self):
+        """Testing adding a new column properly creates a new disk array (list
+        flavor)
+        """
+        N = 10
+        ra = np.fromiter(((i, i * 2.) for i in xrange(N)), dtype='i4,f8')
+        t = bcolz.ctable(ra, rootdir=self.rootdir)
+        c = np.fromiter(("s%d" % i for i in xrange(N)), dtype='S2')
+        t.addcol(c.tolist(), 'f2')
+        ra = np.fromiter(((i, i * 2., "s%d" % i) for i in xrange(N)),
+                         dtype='i4,f8,S2')
+        newpath = os.path.join(self.rootdir, 'f2')
+        assert_array_equal(t[:], ra, "ctable values are not correct")
+        assert_array_equal(bcolz.carray(rootdir=newpath)[:], ra['f2'])
+
+    def test_del_new_column_ondisk(self):
+        """Testing adding a new column properly creates a new disk array (list
+        flavor)
+        """
+        N = 10
+        ra = np.fromiter(((i, i * 2.) for i in xrange(N)), dtype='i4,f8')
+        t = bcolz.ctable(ra, rootdir=self.rootdir)
+        c = np.fromiter(("s%d" % i for i in xrange(N)), dtype='S2')
+        t.addcol(c.tolist(), 'f2')
+        ra = np.fromiter(((i, i * 2., "s%d" % i) for i in xrange(N)),
+                         dtype='i4,f8,S2')
+        newpath = os.path.join(self.rootdir, 'f2')
+        assert_array_equal(t[:], ra, "ctable values are not correct")
+        assert_array_equal(bcolz.carray(rootdir=newpath)[:], ra['f2'])
+        t.delcol('f2')
+        self.assertFalse(os.path.exists(newpath))
 
 
 class getitemTest(MayBeDiskTest):

--- a/bcolz/tests/test_ctable.py
+++ b/bcolz/tests/test_ctable.py
@@ -410,6 +410,23 @@ class add_del_colDiskTest(add_del_colTest, TestCase):
         t.delcol('f2')
         self.assertFalse(os.path.exists(newpath))
 
+    def test_add_new_column_ondisk_other_carray_rootdir(self):
+        """Testing adding a new column properly creates a new disk array (list
+        flavor)
+        """
+        N = 10
+        ra = np.fromiter(((i, i * 2.) for i in xrange(N)), dtype='i4,f8')
+        t = bcolz.ctable(ra, rootdir=self.rootdir)
+        c = np.fromiter(("s%d" % i for i in xrange(N)), dtype='S2')
+        _, fn = tempfile.mkstemp()
+        os.remove(fn)
+        t.addcol(bcolz.carray(c, rootdir=fn), 'f2')
+        ra = np.fromiter(((i, i * 2., "s%d" % i) for i in xrange(N)),
+                         dtype='i4,f8,S2')
+        newpath = os.path.join(self.rootdir, 'f2')
+        assert_array_equal(t[:], ra, "ctable values are not correct")
+        assert_array_equal(bcolz.carray(rootdir=newpath)[:], ra['f2'])
+
 
 class getitemTest(MayBeDiskTest):
 

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ def check_import(pkgname, pkgver):
 ########### Check versions ##########
 
 # The minimum version of Cython required for generating extensions
-min_cython_version = '0.20'
+min_cython_version = '0.22'
 # The minimum version of NumPy required
 min_numpy_version = '1.7'
 # The minimum version of Numexpr (optional)


### PR DESCRIPTION
Hi,

I've combined @cpcloud and @esc their improvements and added some extra checks and functionality (it should replace the older pulls + we should be able to close some issues after this) + did my long over-due auto-flush thing:

- addcol/delcol #137 <- I also added something for a use-case where you add a diskbased carray to a diskbased ctable
- purge #130
- rootdir existence check keyerror #123 <- added a check for this
- autoflush #127 (for disk-based ctable creation and append)

So I hope this completely fixes all existing issues with disk-based ctables (we actually made some workarounds ourselves which we can also remove after this pull).

BR

Carst