### PR TITLE
remove workaround for older cython versions and pin 0.22

### DIFF
--- a/bcolz/carray_ext.pyx
+++ b/bcolz/carray_ext.pyx
@@ -315,12 +315,7 @@ cdef class chunk:
         self.atom = atom
         self.atomsize = atom.itemsize
         dtype_ = atom.base
-        # 'kind' isn't defined in the numpy.pxd
-        # kind is of type python str, typekind of type char
-        # in cython char is coerced to int
-        # kind[0] gives us the first character of the string
-        # ord gives us the ascii integer corresponding to that char
-        self.typekind = ord(dtype_.kind[0])
+        self.typekind = dtype_.kind
         # Hack for allowing strings with len > BLOSC_MAX_TYPESIZE
         if self.typekind == 'S':
             itemsize = 1

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ def check_import(pkgname, pkgver):
 ########### Check versions ##########
 
 # The minimum version of Cython required for generating extensions
-min_cython_version = '0.20'
+min_cython_version = '0.22'
 # The minimum version of NumPy required
 min_numpy_version = '1.7'
 # The minimum version of Numexpr (optional)


### PR DESCRIPTION
See also: https://github.com/cython/cython/pull/356