### PR TITLE
recursive include Blosc licences

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -12,3 +12,4 @@ recursive-include bench *.py *.txt
 recursive-include doc *.rst *.txt *.py *.pdf *.html *.css *.png
 recursive-exclude doc/_build *
 recursive-include LICENSES *
+recursive-include c-blosc/LICENSES *


### PR DESCRIPTION
The ``python setup.py sdist`` won't dereference symlinks so simply ship the
symlink targets too.