### PR TITLE
Disk based (updated #140 based on #151 + more atomic commits)

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -7,6 +7,8 @@ Changes from 0.8.1 to 0.9.0
 
 - Implement ``purge``, which removes data for on-disk carrays. (#130 @esc)
 
+- Implement addcol/delcol to properly handle on-disk ctable (#112 @cpcloud)
+
 Changes from 0.8.0 to 0.8.1
 ===========================
 

--- a/bcolz/ctable.py
+++ b/bcolz/ctable.py
@@ -518,10 +518,7 @@ class ctable(object):
         # Remove the column
         col = self.cols.pop(name)
 
-        # remove the data if we have a rootdir
-        if self.rootdir is not None and col.rootdir is not None:
-            # is the col.rootdir is not None check necessary?
-            shutil.rmtree(os.path.join(self.rootdir, name))
+        col.purge()
 
         # Update _arr1
         self._arr1 = np.empty(shape=(1,), dtype=self.dtype)

--- a/bcolz/ctable.py
+++ b/bcolz/ctable.py
@@ -499,6 +499,9 @@ class ctable(object):
         # Update _arr1
         self._arr1 = np.empty(shape=(1,), dtype=self.dtype)
 
+        if self.auto_flush:
+            self.flush()
+
     def delcol(self, name=None, pos=None, keep=False):
         """
         delcol(name=None, pos=None)
@@ -551,6 +554,9 @@ class ctable(object):
 
         # Update _arr1
         self._arr1 = np.empty(shape=(1,), dtype=self.dtype)
+
+        if self.auto_flush:
+            self.flush()
 
     def copy(self, **kwargs):
         """

--- a/bcolz/ctable.py
+++ b/bcolz/ctable.py
@@ -460,7 +460,7 @@ class ctable(object):
 
         kwargs.setdefault('cparams', self.cparams)
 
-        if isinstance(newcol, np.ndarray):
+        if isinstance(newcol, (np.ndarray, bcolz.carray)):
             newcol = bcolz.carray(newcol, **kwargs)
         elif type(newcol) in (list, tuple):
             newcol = bcolz.carray(newcol, **kwargs)

--- a/bcolz/ctable.py
+++ b/bcolz/ctable.py
@@ -179,6 +179,10 @@ class ctable(object):
         # Important optional params
         self._cparams = kwargs.get('cparams', bcolz.cparams())
         self.rootdir = kwargs.get('rootdir', None)
+        if self.rootdir is not None:
+            self.auto_flush = kwargs.get('auto_flush', True)
+        else:
+            self.auto_flush = False
         "The directory where this object is saved."
         if self.rootdir is None and columns is None:
             raise ValueError(
@@ -290,6 +294,9 @@ class ctable(object):
 
         self.len = clen
 
+        if self.auto_flush:
+            self.flush()
+
     def open_ctable(self):
         """Open an existing ctable on-disk."""
 
@@ -368,6 +375,9 @@ class ctable(object):
                     "all cols in `cols` must have the same length")
             clen = clen2
         self.len += clen
+
+        if self.auto_flush:
+            self.flush()
 
     def trim(self, nitems):
         """

--- a/bcolz/ctable.py
+++ b/bcolz/ctable.py
@@ -473,7 +473,7 @@ class ctable(object):
         # Update _arr1
         self._arr1 = np.empty(shape=(1,), dtype=self.dtype)
 
-    def delcol(self, name=None, pos=None):
+    def delcol(self, name=None, pos=None, keep=False):
         """
         delcol(name=None, pos=None)
 
@@ -485,6 +485,8 @@ class ctable(object):
             The name of the column to remove.
         pos: int, optional
             The position of the column to remove.
+        keep: boolean
+            For disk-backed columns: keep the data on disk?
 
         Notes
         -----
@@ -518,7 +520,8 @@ class ctable(object):
         # Remove the column
         col = self.cols.pop(name)
 
-        col.purge()
+        if not keep:
+            col.purge()
 
         # Update _arr1
         self._arr1 = np.empty(shape=(1,), dtype=self.dtype)

--- a/bcolz/ctable.py
+++ b/bcolz/ctable.py
@@ -15,7 +15,6 @@ import itertools
 from collections import namedtuple
 import json
 import os
-import os.path
 import shutil
 from .py2help import _inttypes, _strtypes, imap, xrange
 
@@ -81,7 +80,7 @@ class cols(object):
         """Return the named column and remove it."""
         pos = self.names.index(name)
         name = self.names.pop(pos)
-        col = self._cols[name]
+        col = self._cols.pop(name)
         self.update_meta()
         return col
 
@@ -456,13 +455,14 @@ class ctable(object):
         if len(newcol) != self.len:
             raise ValueError("`newcol` must have the same length than ctable")
 
+        if self.rootdir is not None:
+            kwargs.setdefault('rootdir', os.path.join(self.rootdir, name))
+
+        kwargs.setdefault('cparams', self.cparams)
+
         if isinstance(newcol, np.ndarray):
-            if 'cparams' not in kwargs:
-                kwargs['cparams'] = self.cparams
             newcol = bcolz.carray(newcol, **kwargs)
         elif type(newcol) in (list, tuple):
-            if 'cparams' not in kwargs:
-                kwargs['cparams'] = self.cparams
             newcol = bcolz.carray(newcol, **kwargs)
         elif type(newcol) != bcolz.carray:
             raise ValueError(
@@ -516,7 +516,13 @@ class ctable(object):
             name = self.names[pos]
 
         # Remove the column
-        self.cols.pop(name)
+        col = self.cols.pop(name)
+
+        # remove the data if we have a rootdir
+        if self.rootdir is not None and col.rootdir is not None:
+            # is the col.rootdir is not None check necessary?
+            shutil.rmtree(os.path.join(self.rootdir, name))
+
         # Update _arr1
         self._arr1 = np.empty(shape=(1,), dtype=self.dtype)
 

--- a/bcolz/ctable.py
+++ b/bcolz/ctable.py
@@ -299,6 +299,8 @@ class ctable(object):
 
     def open_ctable(self):
         """Open an existing ctable on-disk."""
+        if self.mode == 'r' and not os.path.exists(self.rootdir):
+            raise KeyError("Disk-based ctable opened with `r`ead mode yet `rootdir` does not exist")
 
         # Open the ctable by reading the metadata
         self.cols.read_meta_and_open()

--- a/bcolz/tests/test_carray.py
+++ b/bcolz/tests/test_carray.py
@@ -2115,6 +2115,28 @@ class PurgeMemoryArrayTest(MayBeDiskTest, TestCase):
         # this should work and should be a noop
         b.purge()
 
+class FlushDiskTest(MayBeDiskTest, TestCase):
+    disk = True
+
+    def test_01(self):
+        '''Testing autoflush new disk-based carray'''
+        a = np.arange(1e2)
+        b = bcolz.carray(a, chunklen=30, rootdir=self.rootdir)
+
+        b = bcolz.open(rootdir=self.rootdir)
+        assert_array_equal(a, b[:], 'not working correctly')
+
+    def test_02(self):
+        '''Testing autoflush when appending data to a disk-based carray'''
+        a = np.arange(1e2)
+        b = bcolz.carray(a, chunklen=20, rootdir=self.rootdir)
+        b.append(-1)
+
+        b = bcolz.open(rootdir=self.rootdir)
+        assert_array_equal(np.append(a, -1), b[:], 'not working correctly')
+
+
+
 if __name__ == '__main__':
     unittest.main(verbosity=2)
 

--- a/bcolz/tests/test_ctable.py
+++ b/bcolz/tests/test_ctable.py
@@ -394,8 +394,7 @@ class add_del_colDiskTest(add_del_colTest, TestCase):
         assert_array_equal(bcolz.carray(rootdir=newpath)[:], ra['f2'])
 
     def test_del_new_column_ondisk(self):
-        """Testing adding a new column properly creates a new disk array (list
-        flavor)
+        """Testing delcol removes data on disk.
         """
         N = 10
         ra = np.fromiter(((i, i * 2.) for i in xrange(N)), dtype='i4,f8')
@@ -427,8 +426,7 @@ class add_del_colDiskTest(add_del_colTest, TestCase):
         self.assertTrue(os.path.exists(newpath))
 
     def test_add_new_column_ondisk_other_carray_rootdir(self):
-        """Testing adding a new column properly creates a new disk array (list
-        flavor)
+        """Testing addcol with different rootdir.
         """
         N = 10
         ra = np.fromiter(((i, i * 2.) for i in xrange(N)), dtype='i4,f8')

--- a/bcolz/tests/test_ctable.py
+++ b/bcolz/tests/test_ctable.py
@@ -410,6 +410,22 @@ class add_del_colDiskTest(add_del_colTest, TestCase):
         t.delcol('f2')
         self.assertFalse(os.path.exists(newpath))
 
+    def test_del_new_column_ondisk(self):
+        """Testing delcol with keep keeps the data.
+        """
+        N = 10
+        ra = np.fromiter(((i, i * 2.) for i in xrange(N)), dtype='i4,f8')
+        t = bcolz.ctable(ra, rootdir=self.rootdir)
+        c = np.fromiter(("s%d" % i for i in xrange(N)), dtype='S2')
+        t.addcol(c.tolist(), 'f2')
+        ra = np.fromiter(((i, i * 2., "s%d" % i) for i in xrange(N)),
+                         dtype='i4,f8,S2')
+        newpath = os.path.join(self.rootdir, 'f2')
+        assert_array_equal(t[:], ra, "ctable values are not correct")
+        assert_array_equal(bcolz.carray(rootdir=newpath)[:], ra['f2'])
+        t.delcol('f2', keep=True)
+        self.assertTrue(os.path.exists(newpath))
+
     def test_add_new_column_ondisk_other_carray_rootdir(self):
         """Testing adding a new column properly creates a new disk array (list
         flavor)

--- a/bcolz/tests/test_ctable.py
+++ b/bcolz/tests/test_ctable.py
@@ -14,13 +14,11 @@ import tempfile
 
 import numpy as np
 from numpy.testing import assert_array_equal, assert_allclose
-from bcolz.tests.common import (
-    MayBeDiskTest, TestCase, unittest, skipUnless)
+from bcolz.tests.common import MayBeDiskTest, TestCase, unittest, skipUnless
 import bcolz
 from bcolz.py2help import xrange, PY2
 import pickle
 import os
-import shutil
 
 
 class createTest(MayBeDiskTest):
@@ -379,6 +377,38 @@ class add_del_colMemoryTest(add_del_colTest, TestCase):
 
 class add_del_colDiskTest(add_del_colTest, TestCase):
     disk = True
+
+    def test_add_new_column_ondisk(self):
+        """Testing adding a new column properly creates a new disk array (list
+        flavor)
+        """
+        N = 10
+        ra = np.fromiter(((i, i * 2.) for i in xrange(N)), dtype='i4,f8')
+        t = bcolz.ctable(ra, rootdir=self.rootdir)
+        c = np.fromiter(("s%d" % i for i in xrange(N)), dtype='S2')
+        t.addcol(c.tolist(), 'f2')
+        ra = np.fromiter(((i, i * 2., "s%d" % i) for i in xrange(N)),
+                         dtype='i4,f8,S2')
+        newpath = os.path.join(self.rootdir, 'f2')
+        assert_array_equal(t[:], ra, "ctable values are not correct")
+        assert_array_equal(bcolz.carray(rootdir=newpath)[:], ra['f2'])
+
+    def test_del_new_column_ondisk(self):
+        """Testing adding a new column properly creates a new disk array (list
+        flavor)
+        """
+        N = 10
+        ra = np.fromiter(((i, i * 2.) for i in xrange(N)), dtype='i4,f8')
+        t = bcolz.ctable(ra, rootdir=self.rootdir)
+        c = np.fromiter(("s%d" % i for i in xrange(N)), dtype='S2')
+        t.addcol(c.tolist(), 'f2')
+        ra = np.fromiter(((i, i * 2., "s%d" % i) for i in xrange(N)),
+                         dtype='i4,f8,S2')
+        newpath = os.path.join(self.rootdir, 'f2')
+        assert_array_equal(t[:], ra, "ctable values are not correct")
+        assert_array_equal(bcolz.carray(rootdir=newpath)[:], ra['f2'])
+        t.delcol('f2')
+        self.assertFalse(os.path.exists(newpath))
 
 
 class getitemTest(MayBeDiskTest):

--- a/bcolz/tests/test_ctable.py
+++ b/bcolz/tests/test_ctable.py
@@ -410,6 +410,23 @@ class add_del_colDiskTest(add_del_colTest, TestCase):
         t.delcol('f2')
         self.assertFalse(os.path.exists(newpath))
 
+    def test_add_new_column_ondisk_other_carray_rootdir(self):
+        """Testing adding a new column properly creates a new disk array (list
+        flavor)
+        """
+        N = 10
+        ra = np.fromiter(((i, i * 2.) for i in xrange(N)), dtype='i4,f8')
+        t = bcolz.ctable(ra, rootdir=self.rootdir)
+        c = np.fromiter(("s%d" % i for i in xrange(N)), dtype='S2')
+        _, fn = tempfile.mkstemp()
+        os.remove(fn)
+        t.addcol(bcolz.carray(c, rootdir=fn), 'f2')
+        ra = np.fromiter(((i, i * 2., "s%d" % i) for i in xrange(N)),
+                         dtype='i4,f8,S2')
+        newpath = os.path.join(self.rootdir, 'f2')
+        assert_array_equal(t[:], ra, "ctable values are not correct")
+        assert_array_equal(bcolz.carray(rootdir=newpath)[:], ra['f2'])
+
 
 class getitemTest(MayBeDiskTest):
 

--- a/bcolz/tests/test_ctable.py
+++ b/bcolz/tests/test_ctable.py
@@ -1951,6 +1951,62 @@ class pickleTest(MayBeDiskTest, TestCase):
         self.assertEquals(type(b2), type(b))
 
 
+class FlushDiskTest(MayBeDiskTest, TestCase):
+    disk = True
+
+    def test_01(self):
+        '''Testing autoflush new disk-based ctable'''
+        N = 100
+        a = np.fromiter(((i, i * 2.) for i in xrange(N)), dtype='i4,f8')
+        # force ctable with leftovers (chunklen=30 and N=100)
+        t = bcolz.ctable(a, chunklen=30, rootdir=self.rootdir)
+
+        t = bcolz.open(rootdir=self.rootdir)
+        assert_array_equal(a, t[:], 'not working correctly')
+
+    def test_02(self):
+        '''Testing autoflush when appending data to a disk-based ctable'''
+        N = 100
+        a = np.fromiter(((i, i * 2.) for i in xrange(N)), dtype='i4,f8')
+        # force ctable with leftovers (N is not a multiple of chunklen)
+        t = bcolz.ctable(a, chunklen=30, rootdir=self.rootdir)
+
+        y = np.array([(-1.0,-2.0)], dtype=[('f0', 'i4'), ('f1', 'f8')])
+        t.append(y)
+
+        t = bcolz.open(rootdir=self.rootdir)
+        assert_array_equal(np.append(a, y, 0), t[:], 'not working correctly')
+
+    def test_03(self):
+        '''Testing autoflush adding column data to a disk-based ctable'''
+        N = 100
+        a = np.fromiter(((i, i * 2.) for i in xrange(N)), dtype='i4,f8')
+        # force ctable with leftovers (N is not a multiple of chunklen)
+        t = bcolz.ctable(a, chunklen=30, rootdir=self.rootdir)
+
+        y = np.fromiter(((i * 3) for i in xrange(N)), dtype='i8')
+        t.addcol(y)
+
+        t = bcolz.open(rootdir=self.rootdir)
+        assert_array_equal(a['f0'], t['f0'], 'not working correctly')
+        assert_array_equal(a['f1'], t['f1'], 'not working correctly')
+        assert_array_equal(y, t['f2'], 'not working correctly')
+
+    def test_04(self):
+        '''Testing autoflush deleting a column to a disk-based ctable'''
+        N = 100
+        a = np.fromiter(((i, i * 2.) for i in xrange(N)), dtype='i4,f8')
+        # force ctable with leftovers (N is not a multiple of chunklen)
+        t = bcolz.ctable(a, chunklen=30, rootdir=self.rootdir)
+
+        y = np.fromiter(((i * 3) for i in xrange(N)), dtype='i8')
+        t.delcol('f1')
+
+        t = bcolz.open(rootdir=self.rootdir)
+        assert_array_equal(a['f0'], t['f0'], 'not working correctly')
+        self.assertTrue('f1' not in t.cols.names)
+
+
 if __name__ == '__main__':
     unittest.main(verbosity=2)
 


### PR DESCRIPTION
Updated #140 for the new master, with @esc his changes in #151 and more atomic commits. This should solve all known issues with handling disk-based ctables & carrays

addcol/delcol #137 <- I also added something for a use-case where you add a diskbased carray to a diskbased ctable
purge #130
rootdir existence check keyerror #123 <- added a check for this
autoflush #127 (for disk-based ctable creation and append)

