### PR TITLE
install carray_ext.pxd with the package

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -19,6 +19,8 @@ Changes from 0.8.1 to 0.9.0
   (``mv``) into the root directory of the ctable.
   (#140 #152 @FrancescElies @CarstVaartjes)
 
+- Distribute ``carray_ext.pxd`` as part of the package. (#159 @ARF)
+
 Changes from 0.8.0 to 0.8.1
 ===========================
 

--- a/setup.py
+++ b/setup.py
@@ -234,5 +234,5 @@ for binary data.
                     extra_compile_args=CFLAGS),
       ],
       packages=['bcolz', 'bcolz.tests'],
-
+      package_data={'bcolz': ['carray_ext.pxd']},
 )


### PR DESCRIPTION
This allows other packages to be cython compiled against the installed bcolz
package. Use case: building bquery