### PR TITLE
introduce chunk._getitem_r(...), a thread-safe version of chunk._getitem(...)

### DIFF
--- a/bcolz/carray_ext.pxd
+++ b/bcolz/carray_ext.pxd
@@ -9,10 +9,14 @@ cdef class chunk:
     cdef object atom, constant, dobject
 
     cdef void _getitem(self, int start, int stop, char *dest)
+    cdef void _getitem_r(self, int start, int stop, char *dest, char *data, 
+                         int nbytes, int atomsize, int itemsize, 
+                         int isconstant, char *constant, int constant_nbytes) nogil
     cdef compress_data(self, char *data, size_t itemsize, size_t nbytes,
                        object cparams)
     cdef compress_arrdata(self, ndarray array, int itemsize,
                           object cparams, object _memory)
+
 
 
 cdef class chunks(object):

--- a/bcolz/definitions.pxd
+++ b/bcolz/definitions.pxd
@@ -24,8 +24,8 @@ cdef extern from "string.h":
     char *strncpy(char *dest, char *src, size_t n)
     int strcmp(char *s1, char *s2)
     char *strdup(char *s)
-    void *memcpy(void *dest, void *src, size_t n)
-    void *memset(void *s, int c, size_t n)
+    void *memcpy(void *dest, void *src, size_t n) nogil
+    void *memset(void *s, int c, size_t n) nogil
 
 cdef extern from "time.h":
     ctypedef int time_t


### PR DESCRIPTION
`chunk._getitem(...)` depends on and modifies instance attributes of `chunk`.
The consequence is that in multi-threaded applications access to the `chunk`
instance has to be controlled by locking which prevent multi-threaded code
based on bcolz from scaling appropriately with the number of processors.

The introduced function `chunk._getitem_r(...)` provides the same functionality
without requiring the GIL or any locking to protect instance attributes. This
allows writing efficient multi-threaded cython algorithms based on bcolz.

Use case: visualfabriq/bquery#22