### PR TITLE
handle trivial boolean expressions in ctable.__getitem__() gracefully

### DIFF
--- a/bcolz/ctable.py
+++ b/bcolz/ctable.py
@@ -1131,8 +1131,15 @@ class ctable(object):
                     raise IndexError(
                         "`key` %s does not represent a boolean "
                         "expression" % key)
-                return self._where(arr)
-            return self.cols[key]
+                elif arr == False:
+                    dtype = np.dtype([(name, self.cols[name].dtype) for name in self.names])
+                    return np.empty(0, dtype=dtype).view(np.ndarray)
+                elif arr == True:
+                    start = stop = step = None
+                else:
+                    return self._where(arr)
+            else:
+                return self.cols[key]
         # All the rest not implemented
         else:
             raise NotImplementedError("key not supported: %s" % repr(key))


### PR DESCRIPTION
Trivial boolean expressions supplied to `ctable.__getitem__()`, i.e. `True` or `False`, or even `(True & False)`, should be handled gracefully.

Example:
```
db = bcolz.ctable(...)
db['False']
```
will return an empty result and similarly:
```
db['True'] == db['(True)'] == db['(((True)))'] == db[:]
```

This PR will simplify the development of query optimizers building on bcolz that restructure complicated query expressions. If an optimizer determines a complicated query to evaluate to logical True/False (e.g. using information from a cached bquery factorization), it can pass this result to bcolz to obtain an appropriately instantiated result.