### PR TITLE
Add safe attribute to carray

### DIFF
--- a/bcolz/carray_ext.pxd
+++ b/bcolz/carray_ext.pxd
@@ -39,6 +39,7 @@ cdef class carray:
     cdef object lastchunkarr, where_arr, arr1
     cdef object _cparams, _dflt
     cdef object _dtype
+    cdef object _safe
     cdef public object chunks
     cdef object _rootdir, datadir, metadir, _mode
     cdef object _attrs, iter_exhausted

--- a/bcolz/carray_ext.pyx
+++ b/bcolz/carray_ext.pyx
@@ -944,7 +944,7 @@ cdef class carray:
             return len(self.shape)
 
     property safe:
-        "The size of this object."
+        "Whether or not to perform type/shape checks on every operation."
         def __get__(self):
             return self._safe
 

--- a/bcolz/tests/test_carray_objects.py
+++ b/bcolz/tests/test_carray_objects.py
@@ -129,6 +129,14 @@ class ObjectCarrayTest(MayBeDiskTest):
             self.assertEqual(carr[i][0], src_data[i][0])
             self.assertEqual(carr[i][1], src_data[i][1])
 
+    def test_create_unsafe_carray_with_unsafe_data(self):
+        """ We introduce a safe keyword arg which removes dtype checking.
+        We don't want this to interfere with creation.
+        """
+        b = bcolz.carray([1, 2, 3], dtype='i4', safe=False)
+        self.assertEqual(b.safe, False)
+        self.assertEqual(b[0], 1)
+
 
 class ObjectCarraymemoryTest(ObjectCarrayTest, TestCase):
     disk = False

--- a/bcolz/utils.py
+++ b/bcolz/utils.py
@@ -99,8 +99,11 @@ def get_len_of_range(start, stop, step):
     return n
 
 
-def to_ndarray(array, dtype, arrlen=None):
+def to_ndarray(array, dtype, arrlen=None, safe=True):
     """Convert object to a ndarray."""
+
+    if not safe:
+        return array
 
     if dtype is None:
         return np.array(array)


### PR DESCRIPTION
This bypasses type, dtype, and stride checking in to_ndarray.
This is unsafe behavior for general users but removes significant
overhead in the "many small writes" case typical of shuffling data.