### PR TITLE
Remove with nogil statement to avoid segfault

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -24,7 +24,8 @@ Changes from 0.8.1 to 0.9.0
 - Add ``safe=`` keyword argument to control dtype/stride checking on append
   (#163 @mrocklin)
 
-- Hold GIL during blosc decompression, avoiding segfaults (#166 @mrocklin)
+- Hold GIL during c-blosc compression/decompression, avoiding some segfaults
+  (#166 @mrocklin)
 
 Changes from 0.8.0 to 0.8.1
 ===========================

--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -24,6 +24,8 @@ Changes from 0.8.1 to 0.9.0
 - Add ``safe=`` keyword argument to control dtype/stride checking on append
   (#163 @mrocklin)
 
+- Hold GIL during blosc decompression, avoiding segfaults (#166 @mrocklin)
+
 Changes from 0.8.0 to 0.8.1
 ===========================
 

--- a/bcolz/carray_ext.pyx
+++ b/bcolz/carray_ext.pyx
@@ -422,9 +422,8 @@ cdef class chunk:
             raise ValueError(
                 "Compressor '%s' is not available in this build" % cname)
         dest = <char *> malloc(nbytes + BLOSC_MAX_OVERHEAD)
-        with nogil:
-            ret = blosc_compress(clevel, shuffle, itemsize, nbytes,
-                                 data, dest, nbytes + BLOSC_MAX_OVERHEAD)
+        ret = blosc_compress(clevel, shuffle, itemsize, nbytes,
+                             data, dest, nbytes + BLOSC_MAX_OVERHEAD)
         if ret <= 0:
             raise RuntimeError(
                 "fatal error during Blosc compression: %d" % ret)
@@ -454,8 +453,7 @@ cdef class chunk:
 
         dest = <char *> malloc(self.nbytes)
         # Fill dest with uncompressed data
-        with nogil:
-            ret = blosc_decompress(self.data, dest, self.nbytes)
+        ret = blosc_decompress(self.data, dest, self.nbytes)
         if ret < 0:
             raise RuntimeError(
                 "fatal error during Blosc decompression: %d" % ret)
@@ -480,7 +478,6 @@ cdef class chunk:
             return
 
         # Fill dest with uncompressed data
-        # TODO: Release GIL once segfault issues cease
         if bsize == self.nbytes:
             ret = blosc_decompress(self.data, dest, bsize)
         else:
@@ -709,8 +706,7 @@ cdef class chunks(object):
                 # Fill lastchunk with data on disk
                 scomp = self.read_chunk(self.nchunks)
                 compressed = PyString_AsString(scomp)
-                with nogil:
-                    ret = blosc_decompress(compressed, lastchunk, chunksize)
+                ret = blosc_decompress(compressed, lastchunk, chunksize)
                 if ret < 0:
                     raise RuntimeError(
                         "error decompressing the last chunk (error code: "

--- a/bcolz/carray_ext.pyx
+++ b/bcolz/carray_ext.pyx
@@ -480,11 +480,11 @@ cdef class chunk:
             return
 
         # Fill dest with uncompressed data
-        with nogil:
-            if bsize == self.nbytes:
-                ret = blosc_decompress(self.data, dest, bsize)
-            else:
-                ret = blosc_getitem(self.data, nstart, nitems, dest)
+        # TODO: Release GIL once segfault issues cease
+        if bsize == self.nbytes:
+            ret = blosc_decompress(self.data, dest, bsize)
+        else:
+            ret = blosc_getitem(self.data, nstart, nitems, dest)
         if ret < 0:
             raise RuntimeError(
                 "fatal error during Blosc decompression: %d" % ret)


### PR DESCRIPTION
Concurrent reads sometimes trigger a segfault somewhere within `blosc_decompress`. 

In principle the old bcolz code seems correct; presumably there is some issue lower down?  For now a cheap solution seems to be to hold on to the GIL.

Full trace is here:

```
Program received signal SIGSEGV, Segmentation fault.
[Switching to Thread 0x7fffd9c7d700 (LWP 28826)]
_int_malloc (av=0x7fffa4000020, bytes=568) at malloc.c:3489
3489	malloc.c: No such file or directory.
(gdb) bt
#0  _int_malloc (av=0x7fffa4000020, bytes=568) at malloc.c:3489
#1  0x00007ffff70907b0 in __GI___libc_malloc (bytes=568) at malloc.c:2891
#2  0x00007ffff707c44d in __fopen_internal (
    filename=0x7fffa4031e90 "/home/mrocklin/data/trip3.bcolz/rate_code/data/__445.blp", 
    mode=0x7fff3fc8bf80 "rb", is32=1) at iofopen.c:73
#3  0x00007ffff7a66717 in open_the_file (f=0x7fffdc338e40, 
    name=0x7fffa4031e90 "/home/mrocklin/data/trip3.bcolz/rate_code/data/__445.blp", 
    mode=0x7ffff7ecddc4 "rb") at Objects/fileobject.c:374
#4  0x00007ffff7a68b52 in file_init (self=0x7fffdc338e40, args=0x7fffa0776098, kwds=0x0)
    at Objects/fileobject.c:2430
#5  0x00007ffff7aa3208 in type_call (type=<optimized out>, args=0x7fffa0776098, kwds=0x0)
    at Objects/typeobject.c:745
#6  0x00007ffff7a40323 in PyObject_Call (func=0x7ffff7d9c820 <PyFile_Type>, arg=<optimized out>, 
    kw=<optimized out>) at Objects/abstract.c:2529
#7  0x00007fffe1d7dac1 in __Pyx_PyObject_Call (func=0x7ffff7fcda70, arg=arg@entry=0x7fffa0776098, 
    kw=0x0) at bcolz/carray_ext.c:37718
#8  0x00007fffe1dc70b6 in __pyx_f_5bcolz_10carray_ext_6chunks_read_chunk (
    __pyx_v_self=<optimized out>, __pyx_v_nchunk=0x11fce10) at bcolz/carray_ext.c:9434
#9  0x00007fffe1d8532d in __pyx_pf_5bcolz_10carray_ext_6chunks_2__getitem__ (
    __pyx_v_nchunk=0x11fce10, __pyx_v_self=0x7fffe1b40ad0) at bcolz/carray_ext.c:9867
#10 __pyx_pw_5bcolz_10carray_ext_6chunks_3__getitem__ (__pyx_v_self=0x7fffe1b40ad0, 
    __pyx_v_nchunk=0x11fce10) at bcolz/carray_ext.c:9809
#11 0x00007fffe1d7a07a in __pyx_sq_item_5bcolz_10carray_ext_chunks (o=0x7fffe1b40ad0, 
    i=<optimized out>) at bcolz/carray_ext.c:34563
#12 0x00007fffe1dba1d0 in __Pyx_GetItemInt_Fast (is_list=0, wraparound=1, boundscheck=1, i=445, 
    o=<optimized out>) at bcolz/carray_ext.c:38415
#13 __pyx_pf_5bcolz_10carray_ext_6carray_38__getitem__ (__pyx_v_key=<optimized out>, 
    __pyx_v_self=<optimized out>) at bcolz/carray_ext.c:24885
#14 __pyx_pw_5bcolz_10carray_ext_6carray_39__getitem__ (__pyx_v_self=<optimized out>, 
    __pyx_v_key=<optimized out>) at bcolz/carray_ext.c:23217
#15 0x00007fffe1db8ab3 in __pyx_pf_5bcolz_10carray_ext_6carray_38__getitem__ (
    __pyx_v_key=0x7fffdb406d10, __pyx_v_self=0x7fffe2969bd0) at bcolz/carray_ext.c:23668
#16 __pyx_pw_5bcolz_10carray_ext_6carray_39__getitem__ (__pyx_v_self=0x7fffe2969bd0, 
    __pyx_v_key=0x7fffdb406d10) at bcolz/carray_ext.c:23217
#17 0x00007ffff54a3b3d in op_getitem (s=<optimized out>, a=<optimized out>)
    at -------src-dir-------/Python-2.7.9/Modules/operator.c:130
#18 0x00007ffff7af022f in ext_do_call (nk=-1742972520, na=<optimized out>, flags=<optimized out>, 
    pp_stack=0x7fffd9c7b408, func=0x7ffff5f09f38) at Python/ceval.c:4343
#19 PyEval_EvalFrameEx (f=<optimized out>, throwflag=<optimized out>) at Python/ceval.c:2718
#20 0x00007ffff7af1c6e in PyEval_EvalCodeEx (co=0x7fffdc3b27b0, globals=<optimized out>, 
    locals=<optimized out>, args=<optimized out>, argcount=2, kws=0x7fffc4004910, kwcount=0, 
    defs=0x7fffdc3b3a28, defcount=1, closure=0x0) at Python/ceval.c:3265
#21 0x00007ffff7af02aa in fast_function (nk=<optimized out>, na=2, n=<optimized out>, 
    pp_stack=0x7fffd9c7b608, func=0x7fffdc32b050) at Python/ceval.c:4129
#22 call_function (oparg=<optimized out>, pp_stack=0x7fffd9c7b608) at Python/ceval.c:4054
#23 PyEval_EvalFrameEx (f=<optimized out>, throwflag=<optimized out>) at Python/ceval.c:2679
#24 0x00007ffff7a6421c in gen_send_ex (gen=0x7fffdb3f8820, arg=0x0, exc=<optimized out>)
    at Objects/genobject.c:85
#25 0x00007ffff7a3f62b in PyIter_Next (iter=<optimized out>) at Objects/abstract.c:3103
#26 0x00007ffff7ae44da in builtin_zip (self=<optimized out>, args=<optimized out>)
    at Python/bltinmodule.c:2555
#27 0x00007ffff7af022f in ext_do_call (nk=-1603221672, na=<optimized out>, flags=<optimized out>, 
    pp_stack=0x7fffd9c7b7f8, func=0x7ffff7fcdea8) at Python/ceval.c:4343
---Type <return> to continue, or q <return> to quit---
#28 PyEval_EvalFrameEx (f=<optimized out>, throwflag=<optimized out>) at Python/ceval.c:2718
#29 0x00007ffff7af1c6e in PyEval_EvalCodeEx (co=0x7fffdc3b27b0, globals=<optimized out>, 
    locals=<optimized out>, args=<optimized out>, argcount=2, kws=0x7fffa40398f0, kwcount=0, 
    defs=0x7fffdc3b3a28, defcount=1, closure=0x0) at Python/ceval.c:3265
#30 0x00007ffff7af02aa in fast_function (nk=<optimized out>, na=2, n=<optimized out>, 
    pp_stack=0x7fffd9c7b9f8, func=0x7fffdc32b050) at Python/ceval.c:4129
#31 call_function (oparg=<optimized out>, pp_stack=0x7fffd9c7b9f8) at Python/ceval.c:4054
#32 PyEval_EvalFrameEx (f=<optimized out>, throwflag=<optimized out>) at Python/ceval.c:2679
#33 0x00007ffff7af1c6e in PyEval_EvalCodeEx (co=0x7fffdc3b27b0, globals=<optimized out>, 
    locals=<optimized out>, args=<optimized out>, argcount=2, kws=0x7fffc0002c90, kwcount=0, 
    defs=0x7fffdc3b3a28, defcount=1, closure=0x0) at Python/ceval.c:3265
#34 0x00007ffff7af02aa in fast_function (nk=<optimized out>, na=2, n=<optimized out>, 
    pp_stack=0x7fffd9c7bbf8, func=0x7fffdc32b050) at Python/ceval.c:4129
#35 call_function (oparg=<optimized out>, pp_stack=0x7fffd9c7bbf8) at Python/ceval.c:4054
#36 PyEval_EvalFrameEx (f=<optimized out>, throwflag=<optimized out>) at Python/ceval.c:2679
#37 0x00007ffff7af1c6e in PyEval_EvalCodeEx (co=0x7fffdc3b27b0, globals=<optimized out>, 
    locals=<optimized out>, args=<optimized out>, argcount=2, kws=0x7fffa4003750, kwcount=0, 
    defs=0x7fffdc3b3a28, defcount=1, closure=0x0) at Python/ceval.c:3265
#38 0x00007ffff7af02aa in fast_function (nk=<optimized out>, na=2, n=<optimized out>, 
    pp_stack=0x7fffd9c7bdf8, func=0x7fffdc32b050) at Python/ceval.c:4129
#39 call_function (oparg=<optimized out>, pp_stack=0x7fffd9c7bdf8) at Python/ceval.c:4054
#40 PyEval_EvalFrameEx (f=<optimized out>, throwflag=<optimized out>) at Python/ceval.c:2679
#41 0x00007ffff7af1c6e in PyEval_EvalCodeEx (co=0x7fffdc3b27b0, globals=<optimized out>, 
    locals=<optimized out>, args=<optimized out>, argcount=2, kws=0x7fffb4064210, kwcount=0, 
    defs=0x7fffdc3b3a28, defcount=1, closure=0x0) at Python/ceval.c:3265
#42 0x00007ffff7af02aa in fast_function (nk=<optimized out>, na=2, n=<optimized out>, 
    pp_stack=0x7fffd9c7bff8, func=0x7fffdc32b050) at Python/ceval.c:4129
#43 call_function (oparg=<optimized out>, pp_stack=0x7fffd9c7bff8) at Python/ceval.c:4054
#44 PyEval_EvalFrameEx (f=<optimized out>, throwflag=<optimized out>) at Python/ceval.c:2679
#45 0x00007ffff7af1c6e in PyEval_EvalCodeEx (co=0x7fffdc3b27b0, globals=<optimized out>, 
    locals=<optimized out>, args=<optimized out>, argcount=2, kws=0x7fffa4003968, kwcount=0, 
    defs=0x7fffdc3b3a28, defcount=1, closure=0x0) at Python/ceval.c:3265
#46 0x00007ffff7af02aa in fast_function (nk=<optimized out>, na=2, n=<optimized out>, 
    pp_stack=0x7fffd9c7c1f8, func=0x7fffdc32b050) at Python/ceval.c:4129
#47 call_function (oparg=<optimized out>, pp_stack=0x7fffd9c7c1f8) at Python/ceval.c:4054
#48 PyEval_EvalFrameEx (f=<optimized out>, throwflag=<optimized out>) at Python/ceval.c:2679
#49 0x00007ffff7af1c6e in PyEval_EvalCodeEx (co=0x7fffdc3b28b0, globals=<optimized out>, 
    locals=<optimized out>, args=<optimized out>, argcount=5, kws=0x7ffff7f92068, kwcount=0, 
    defs=0x7fffdc3b3b68, defcount=1, closure=0x0) at Python/ceval.c:3265
#50 0x00007ffff7a6f958 in function_call (func=0x7fffdc32b0c8, arg=0x7fffdbcae4d0, kw=0x7fffdbed2910)
    at Objects/funcobject.c:526
#51 0x00007ffff7a40323 in PyObject_Call (func=0x7fffdc32b0c8, arg=<optimized out>, 
    kw=<optimized out>) at Objects/abstract.c:2529
#52 0x00007ffff7aee865 in ext_do_call (nk=-607460144, na=<optimized out>, flags=<optimized out>, 
    pp_stack=0x7fffd9c7c4c8, func=0x7fffdc32b0c8) at Python/ceval.c:4346
#53 PyEval_EvalFrameEx (f=<optimized out>, throwflag=<optimized out>) at Python/ceval.c:2718
#54 0x00007ffff7af1c6e in PyEval_EvalCodeEx (co=0x7fffdbece830, globals=<optimized out>, 
    locals=<optimized out>, args=<optimized out>, argcount=5, kws=0x7ffff7f92068, kwcount=0, 
    defs=0x7fffdc349f68, defcount=3, closure=0x0) at Python/ceval.c:3265
#55 0x00007ffff7a6f958 in function_call (func=0x7fffdbed3b90, arg=0x7fffdbcae050, kw=0x7fffdbee15c8)
    at Objects/funcobject.c:526
#56 0x00007ffff7a40323 in PyObject_Call (func=0x7fffdbed3b90, arg=<optimized out>, 
    kw=<optimized out>) at Objects/abstract.c:2529
```

Relevant line numbers often point to [this carray_ext.c file](https://gist.githubusercontent.com/mrocklin/60fd4f914198bea3b863/raw/carray_ext.c)