### PR TITLE
issue regarding deletion of moved columns

### DIFF
--- a/bcolz/ctable.py
+++ b/bcolz/ctable.py
@@ -491,7 +491,7 @@ class ctable(object):
                 shutil.move(newcol.rootdir, col_rootdir)
                 newcol.rootdir = col_rootdir
             else:  # copy the the carray
-                shutil.copytree(newcol.rootdir, col_rootdir)
+                newcol = newcol.copy(rootdir=col_rootdir)
         elif isinstance(newcol, (np.ndarray, bcolz.carray)):
             newcol = bcolz.carray(newcol, **kwargs)
         elif type(newcol) in (list, tuple):

--- a/bcolz/tests/test_ctable.py
+++ b/bcolz/tests/test_ctable.py
@@ -435,12 +435,15 @@ class add_del_colDiskTest(add_del_colTest, TestCase):
         c = np.fromiter(("s%d" % i for i in xrange(N)), dtype='S2')
         _, fn = tempfile.mkstemp()
         os.remove(fn)
-        t.addcol(bcolz.carray(c, rootdir=fn), 'f2')
+        c = bcolz.carray(c, rootdir=fn)
+        t.addcol(c, 'f2')
         ra = np.fromiter(((i, i * 2., "s%d" % i) for i in xrange(N)),
                          dtype='i4,f8,S2')
         newpath = os.path.join(self.rootdir, 'f2')
         assert_array_equal(t[:], ra, "ctable values are not correct")
         assert_array_equal(bcolz.carray(rootdir=newpath)[:], ra['f2'])
+        self.assertEqual(fn, c.rootdir)
+        self.assertEqual(newpath, t['f2'].rootdir)
 
 
 class getitemTest(MayBeDiskTest):


### PR DESCRIPTION
As reported in #137 there is an issue with removing on-disk columns that had been created previously elsewhere:

http://nbviewer.ipython.org/gist/alimanfoo/6cc03872fe8054e63860/bcolz_ctable_delcol.ipynb

Basically, the problem is that when moving a column into the ctable, the rootdir of that carray isn't being updated.
