### PR TITLE
Resolves #136

### DIFF
--- a/bcolz/ctable.py
+++ b/bcolz/ctable.py
@@ -146,7 +146,15 @@ class ctable(object):
     def dtype(self):
         "The data type of this object (numpy dtype)."
         names, cols = self.names, self.cols
-        l = [(name, cols[name].dtype) for name in names]
+        l = []
+        for name in names:
+            col = cols[name]
+            if col.ndim == 1:
+                t = (name, col.dtype)
+            else:
+                # column is multidimensional
+                t = (name, (col.dtype, col.shape[1:]))
+            l.append(t)
         return np.dtype(l)
 
     @property

--- a/bcolz/ctable.py
+++ b/bcolz/ctable.py
@@ -149,11 +149,9 @@ class ctable(object):
         l = []
         for name in names:
             col = cols[name]
-            if col.ndim == 1:
-                t = (name, col.dtype)
-            else:
-                # column is multidimensional
-                t = (name, (col.dtype, col.shape[1:]))
+            # Need to account for multidimensional columns
+            t = (name, col.dtype) if col.ndim == 1 else \
+                (name, (col.dtype, col.shape[1:]))
             l.append(t)
         return np.dtype(l)
 

--- a/bcolz/tests/test_ctable.py
+++ b/bcolz/tests/test_ctable.py
@@ -505,6 +505,34 @@ class getitemTest(MayBeDiskTest):
         assert_array_equal(t[colnames][:], ra2,
                            "ctable values are not correct")
 
+    def test05(self):
+        """Testing __getitem__ with total slice"""
+        N = 10
+        ra = np.fromiter(((i, i * 2.) for i in xrange(N)), dtype='i4,f8')
+        t = bcolz.ctable(ra, rootdir=self.rootdir)
+        assert_array_equal(t[:], ra[:],
+                           "ctable values are not correct")
+
+    def test05a(self):
+        """Testing __getitem__ with total slice"""
+        N = 10
+        ra = np.fromiter(((i, i * 2.) for i in xrange(N)), dtype='i4,f8')
+        t = bcolz.ctable(ra, rootdir=self.rootdir)
+        assert_array_equal(t[:], ra[:],
+                           "ctable values are not correct")
+
+    def test05b(self):
+        """Testing __getitem__ with total slice for table including a
+        multidimensional column"""
+        N = 10
+        # N.B., col1 is 2D
+        ra = np.fromiter(((i, (i * 2., i * 4.))
+                          for i in xrange(N)),
+                          dtype=[('col0', 'i4'), ('col1', ('f8', 2))])
+        t = bcolz.ctable(ra, rootdir=self.rootdir)
+        assert_array_equal(t[:], ra[:],
+                           "ctable values are not correct")
+
 
 class getitemMemoryTest(getitemTest, TestCase):
     disk = False

--- a/bcolz/tests/test_ctable.py
+++ b/bcolz/tests/test_ctable.py
@@ -505,14 +505,6 @@ class getitemTest(MayBeDiskTest):
         assert_array_equal(t[colnames][:], ra2,
                            "ctable values are not correct")
 
-    def test05(self):
-        """Testing __getitem__ with total slice"""
-        N = 10
-        ra = np.fromiter(((i, i * 2.) for i in xrange(N)), dtype='i4,f8')
-        t = bcolz.ctable(ra, rootdir=self.rootdir)
-        assert_array_equal(t[:], ra[:],
-                           "ctable values are not correct")
-
     def test05a(self):
         """Testing __getitem__ with total slice"""
         N = 10


### PR DESCRIPTION
This PR resolves #136 by modifying the ctable dtype to support multidimensional columns. Included are test cases for attempting to retrieve a total slice ([:]) from a ctable, which previously failed if the ctable had a column with >1 ndim.