### PR TITLE
adding pickle mechanism without rootdir #182

### DIFF
--- a/bcolz/carray_ext.pyx
+++ b/bcolz/carray_ext.pyx
@@ -2147,7 +2147,7 @@ cdef class carray:
             nwrow += blen
 
         # Safety check
-        #assert (nwrow == vlen)
+        assert (nwrow == vlen)
 
     # This is a private function that is specific for `eval`
     def _getrange(self, npy_intp start, npy_intp blen, ndarray out):
@@ -2592,7 +2592,7 @@ cdef class carray:
 
     def __str__(self):
         return array2string(self)
-    
+
     def __repr__(self):
         snbytes = utils.human_readable_size(self._nbytes)
         scbytes = utils.human_readable_size(self._cbytes)

--- a/bcolz/carray_ext.pyx
+++ b/bcolz/carray_ext.pyx
@@ -2147,7 +2147,7 @@ cdef class carray:
             nwrow += blen
 
         # Safety check
-        assert (nwrow == vlen)
+        #assert (nwrow == vlen)
 
     # This is a private function that is specific for `eval`
     def _getrange(self, npy_intp start, npy_intp blen, ndarray out):
@@ -2592,7 +2592,7 @@ cdef class carray:
 
     def __str__(self):
         return array2string(self)
- 
+    
     def __repr__(self):
         snbytes = utils.human_readable_size(self._nbytes)
         scbytes = utils.human_readable_size(self._cbytes)

--- a/bcolz/carray_ext.pyx
+++ b/bcolz/carray_ext.pyx
@@ -2592,7 +2592,7 @@ cdef class carray:
 
     def __str__(self):
         return array2string(self)
-
+ 
     def __repr__(self):
         snbytes = utils.human_readable_size(self._nbytes)
         scbytes = utils.human_readable_size(self._cbytes)
@@ -2608,7 +2608,11 @@ cdef class carray:
         return fullrepr
 
     def __reduce__(self):
-        return (build_carray, (self.rootdir,))
+        if self.rootdir :
+            return (build_carray, (None,self.rootdir,))
+        else: 
+            return (build_carray,(self[:],None,))
+
 
 ## Local Variables:
 ## mode: python

--- a/bcolz/tests/test_carray.py
+++ b/bcolz/tests/test_carray.py
@@ -77,6 +77,17 @@ class pickleTest(MayBeDiskTest, TestCase):
         b2 = pickle.loads(s)
         self.assertEquals(b2.rootdir, b.rootdir)
 
+class pickleTestMemory(MayBeDiskTest, TestCase):
+    disk=False
+    def test_pickleable(self):
+        a = np.arange(1e2)
+        b = bcolz.carray(a, )
+        s = pickle.dumps(b)
+        if PY2:
+            self.assertTrue(type(s), str)
+        else:
+            self.assertTrue(type(s), bytes)
+
 
 class getitemTest(MayBeDiskTest):
 

--- a/bcolz/tests/test_carray.py
+++ b/bcolz/tests/test_carray.py
@@ -66,8 +66,9 @@ class chunkTest(TestCase):
 class pickleTest(MayBeDiskTest, TestCase):
     disk=True
     def test_pickleable(self):
-        a = np.arange(1e2)
+        a = bcolz.arange(1e2)
         b = bcolz.carray(a, rootdir=self.rootdir)
+
         s = pickle.dumps(b)
         if PY2:
             self.assertTrue(type(s), str)
@@ -84,9 +85,9 @@ class pickleTestMemory(MayBeDiskTest, TestCase):
         b = bcolz.carray(a, )
         s = pickle.dumps(b)
         if PY2:
-            self.assertTrue(type(s), str)
+            self.assertIsInstance(s, str)
         else:
-            self.assertTrue(type(s), bytes)
+            self.assertIsInstance(s, bytes)
 
 
 class getitemTest(MayBeDiskTest):

--- a/bcolz/tests/test_carray.py
+++ b/bcolz/tests/test_carray.py
@@ -68,7 +68,6 @@ class pickleTest(MayBeDiskTest, TestCase):
     def test_pickleable(self):
         a = bcolz.arange(1e2)
         b = bcolz.carray(a, rootdir=self.rootdir)
-
         s = pickle.dumps(b)
         if PY2:
             self.assertTrue(type(s), str)

--- a/bcolz/tests/test_ctable.py
+++ b/bcolz/tests/test_ctable.py
@@ -1980,9 +1980,9 @@ class pickleTest(MayBeDiskTest, TestCase):
                          rootdir=None)
         s = pickle.dumps(b)
         if PY2:
-            self.assertTrue(type(s), str)
+            self.assertIsInstance(s, str)
         else:
-            self.assertTrue(type(s), bytes)
+            self.assertIsInstance(s, bytes)
 
         b2 = pickle.loads(s)
         self.assertEquals(type(b2), type(b))

--- a/bcolz/tests/test_ctable.py
+++ b/bcolz/tests/test_ctable.py
@@ -1974,6 +1974,18 @@ class pickleTest(MayBeDiskTest, TestCase):
         self.assertEquals(b2.rootdir, b.rootdir)
         self.assertEquals(type(b2), type(b))
 
+    def test_pickleable_memory(self):
+        b = bcolz.ctable([[1, 2, 3], [1, 2, 3]],
+                         names=['a', 'b'],
+                         rootdir=None)
+        s = pickle.dumps(b)
+        if PY2:
+            self.assertTrue(type(s), str)
+        else:
+            self.assertTrue(type(s), bytes)
+
+        b2 = pickle.loads(s)
+        self.assertEquals(type(b2), type(b))
 
 class FlushDiskTest(MayBeDiskTest, TestCase):
     disk = True

--- a/bcolz/utils.py
+++ b/bcolz/utils.py
@@ -150,14 +150,17 @@ def human_readable_size(size):
     else:
         return "%.2f TB" % (size / float(2**40))
 
-def build_carray(rootdir):
+def build_carray(array,rootdir):
     """ Used in ctable.__reduce__
 
     Pickling functions can't be in pyx files.  Putting this tiny helper
     function here instead.
     """
     from bcolz import carray
-    return carray(rootdir=rootdir)
+    if rootdir:
+        return carray(rootdir=rootdir)
+    else:
+        return carray(array)
 
 
 # Main part


### PR DESCRIPTION
carray.append works on objects without rootdir #182

``` python
import bcolz
b1 = bcolz.carray(["Hello", None])
b2 = bcolz.carray(["World"])
b1.append(b2)
b1
Out[4]:
carray((3,), object)
  nbytes: 199; cbytes: 631; ratio: 0.32
  cparams := cparams(clevel=5, shuffle=True, cname='blosclz')
[Hello None ['World']]
```
pickle works as well.
```python
import pickle
a=bcolz.carray([1,2,3])
e=pickle.dumps(a)
pickle.loads(e)
Out[7]:
carray((3,), int64)
  nbytes: 24; cbytes: 16.00 KB; ratio: 0.00
  cparams := cparams(clevel=5, shuffle=True, cname='blosclz')
[1 2 3]
```
