### PR TITLE
simple 'to numpy array' wrapper

### DIFF
--- a/bcolz/carray_ext.pyx
+++ b/bcolz/carray_ext.pyx
@@ -526,6 +526,9 @@ cdef class chunk:
             return array[::step]
         return array
 
+    def to_numpy_array(self):
+        return self[:]
+
     @property
     def pointer(self):
         return <Py_uintptr_t> self.data + BLOSCPACK_HEADER_LENGTH


### PR DESCRIPTION
I keep looking for this in the docs, until I realize one needs to do a '[:]'