### PR TITLE
Fix using the auto_flush keyword in the ctable constructor

### DIFF
--- a/bcolz/ctable.py
+++ b/bcolz/ctable.py
@@ -186,6 +186,8 @@ class ctable(object):
             self.auto_flush = kwargs.pop('auto_flush', True)
         else:
             self.auto_flush = False
+            # We actually need to pop it from the kwargs, so it doesn't get
+            # passed down to the carray.
             try:
                 kwargs.pop('auto_flush')
             except KeyError:

--- a/bcolz/ctable.py
+++ b/bcolz/ctable.py
@@ -183,9 +183,13 @@ class ctable(object):
         self._cparams = kwargs.get('cparams', bcolz.cparams())
         self.rootdir = kwargs.get('rootdir', None)
         if self.rootdir is not None:
-            self.auto_flush = kwargs.get('auto_flush', True)
+            self.auto_flush = kwargs.pop('auto_flush', True)
         else:
             self.auto_flush = False
+            try:
+                kwargs.pop('auto_flush')
+            except KeyError:
+                pass
         "The directory where this object is saved."
         if self.rootdir is None and columns is None:
             raise ValueError(

--- a/bcolz/tests/test_ctable.py
+++ b/bcolz/tests/test_ctable.py
@@ -1986,6 +1986,7 @@ class pickleTest(MayBeDiskTest, TestCase):
         b2 = pickle.loads(s)
         self.assertEquals(type(b2), type(b))
 
+
 class FlushDiskTest(MayBeDiskTest, TestCase):
     disk = True
 

--- a/bcolz/tests/test_ctable.py
+++ b/bcolz/tests/test_ctable.py
@@ -2103,6 +2103,15 @@ class FlushDiskTest(MayBeDiskTest, TestCase):
         self.assertTrue(len(t) == 1)
         self.assertTrue(t["a"][0] == b"aaaaa", t["a"][0])
 
+    def test_auto_flush_constructor_keyword_true(self):
+        t = bcolz.ctable([np.empty(0, dtype='i8')], auto_flush=True)
+        self.assertTrue(t.auto_flush)
+
+    def test_auto_flush_constructor_keyword_false(self):
+        t = bcolz.ctable([np.empty(0, dtype='i8')], auto_flush=False)
+        self.assertFalse(t.auto_flush)
+
+
 if __name__ == '__main__':
     unittest.main(verbosity=2)
 

--- a/bcolz/tests/test_ctable.py
+++ b/bcolz/tests/test_ctable.py
@@ -2103,12 +2103,24 @@ class FlushDiskTest(MayBeDiskTest, TestCase):
         self.assertTrue(len(t) == 1)
         self.assertTrue(t["a"][0] == b"aaaaa", t["a"][0])
 
-    def test_auto_flush_constructor_keyword_true(self):
+    def test_auto_flush_constructor_keyword_true_memory(self):
         t = bcolz.ctable([np.empty(0, dtype='i8')], auto_flush=True)
+        #self.assertTrue(t.auto_flush)
+        # attribute will be False, since it is always false for MemCarray.
+        self.assertFalse(t.auto_flush)
+
+    def test_auto_flush_constructor_keyword_true_disk(self):
+        t = bcolz.ctable([np.empty(0, dtype='i8')],
+                         rootdir=self.rootdir, auto_flush=True)
         self.assertTrue(t.auto_flush)
 
-    def test_auto_flush_constructor_keyword_false(self):
+    def test_auto_flush_constructor_keyword_false_memory(self):
         t = bcolz.ctable([np.empty(0, dtype='i8')], auto_flush=False)
+        self.assertFalse(t.auto_flush)
+
+    def test_auto_flush_constructor_keyword_false_disk(self):
+        t = bcolz.ctable([np.empty(0, dtype='i8')],
+                         rootdir=self.rootdir, auto_flush=False)
         self.assertFalse(t.auto_flush)
 
 


### PR DESCRIPTION
It wasn't possible to initialize a ctable with the auto_flush keyword at all.

Problem is: the **kwargs are being sent through to any new carrays and these
don't support this keyword argument.

There are multiple approaches to solving this problem:

a) Pop the auto_flush keyword from the **kwargs if it exists (current solution)

b) Implement auto_flush in the carray

c) Remove the auto_flush keyword entirely in favour of with statement.
   (Although this might not be enough to support all use-cases.)