### PR TITLE
remove compat layer and rename

### DIFF
--- a/bcolz/PythonHelper.h
+++ b/bcolz/PythonHelper.h
@@ -8,9 +8,6 @@
 #include "Python.h"
 
 #if PY_VERSION_HEX >= 0x03000000
-#define PyString_FromStringAndSize(v, len) PyBytes_FromStringAndSize(v, len)
-#define PyString_AsString(v) PyBytes_AsString(v)
-#define PyString_GET_SIZE(string) PyBytes_GET_SIZE(string)
 #define PyBuffer_FromMemory(ptr, size) PyMemoryView_FromMemory(ptr, size, PyBUF_READ|PyBUF_WRITE)
 #endif
 

--- a/bcolz/carray_ext.pyx
+++ b/bcolz/carray_ext.pyx
@@ -75,9 +75,9 @@ from definitions cimport (malloc,
                           memset,
                           strdup,
                           strcmp,
-                          PyString_AsString,
-                          PyString_GET_SIZE,
-                          PyString_FromStringAndSize,
+                          PyBytes_AsString,
+                          PyBytes_GET_SIZE,
+                          PyBytes_FromStringAndSize,
                           Py_BEGIN_ALLOW_THREADS,
                           Py_END_ALLOW_THREADS,
                           PyBuffer_FromMemory,
@@ -335,15 +335,15 @@ cdef class chunk:
 
         if _compr:
             # Data comes in an already compressed state inside a Python String
-            self.data = PyString_AsString(dobject)
+            self.data = PyBytes_AsString(dobject)
             # Increment the reference so that data don't go away
             self.dobject = dobject
             # Set size info for the instance
             blosc_cbuffer_sizes(self.data, &nbytes, &cbytes, &blocksize)
         elif dtype_ == 'O':
             # The objects should arrive here already pickled
-            data = PyString_AsString(dobject)
-            nbytes = PyString_GET_SIZE(dobject)
+            data = PyBytes_AsString(dobject)
+            nbytes = PyBytes_GET_SIZE(dobject)
             cbytes, blocksize = self.compress_data(data, 1, nbytes, cparams)
         else:
             # Compress the data object (a NumPy object)
@@ -442,7 +442,7 @@ cdef class chunk:
 
         assert (not self.isconstant,
                 "This function can only be used for persistency")
-        string = PyString_FromStringAndSize(self.data,
+        string = PyBytes_FromStringAndSize(self.data,
                                             <Py_ssize_t> self.cdbytes)
         return string
 
@@ -457,7 +457,7 @@ cdef class chunk:
         if ret < 0:
             raise RuntimeError(
                 "fatal error during Blosc decompression: %d" % ret)
-        string = PyString_FromStringAndSize(dest, <Py_ssize_t> self.nbytes)
+        string = PyBytes_FromStringAndSize(dest, <Py_ssize_t> self.nbytes)
         return string
 
     cdef void _getitem(self, int start, int stop, char *dest):
@@ -705,7 +705,7 @@ cdef class chunks(object):
             if leftover:
                 # Fill lastchunk with data on disk
                 scomp = self.read_chunk(self.nchunks)
-                compressed = PyString_AsString(scomp)
+                compressed = PyBytes_AsString(scomp)
                 ret = blosc_decompress(compressed, lastchunk, chunksize)
                 if ret < 0:
                     raise RuntimeError(

--- a/bcolz/definitions.pxd
+++ b/bcolz/definitions.pxd
@@ -59,10 +59,10 @@ cdef extern from "PythonHelper.h":
     object PyFloat_FromDouble(double)
 
     # Functions for strings
-    object PyString_FromString(char *)
-    object PyString_FromStringAndSize(char *s, int len)
-    char *PyString_AsString(object string)
-    size_t PyString_GET_SIZE(object string)
+    object PyBytes_FromString(char *)
+    object PyBytes_FromStringAndSize(char *s, int len)
+    char *PyBytes_AsString(object string)
+    size_t PyBytes_GET_SIZE(object string)
 
     # Functions for lists
     int PyList_Append(object list, object item)


### PR DESCRIPTION
IIRC before Python version 2.6 we still needed the compat layer, now we can
just go ahead and call everything PyBytes_* as it is suppoed to be in Python
3.x.