### PR TITLE
Creating ctable with rootdir kwarg causes ValueError: You cannot pass a `columns` param in 'a'ppend mode

### DIFF
--- a/bcolz/ctable.py
+++ b/bcolz/ctable.py
@@ -196,7 +196,9 @@ class ctable(object):
             self.mode = kwargs.setdefault('mode', 'a')
             if columns is not None and self.mode == 'a':
                 raise ValueError(
-                    "You cannot pass a `columns` param in 'a'ppend mode")
+                    "You cannot pass a `columns` param in 'a'ppend mode.\n"
+                    "(If you are trying to create a new ctable, perhaps the "
+                    "directory exists already.)")
         else:
             self.mode = kwargs.setdefault('mode', 'w')
 


### PR DESCRIPTION
```python
print bcolz.__version__
N = 100*100
ct = bcolz.fromiter(((i,i*i) for i in xrange(N)), dtype="i4,f8", count=N, rootdir='test')
new_col = np.linspace(0, 1, 100*100)
ct.addcol(new_col)
```

```
0.8.1
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
<ipython-input-29-6c6f9912fdbb> in <module>()
      1 print bcolz.__version__
      2 N = 100*100
----> 3 ct = bcolz.fromiter(((i,i*i) for i in xrange(N)), dtype="i4,f8", count=N, rootdir='test')
      4 new_col = np.linspace(0, 1, 100*100)
      5 ct.addcol(new_col)

/opt/miniconda/lib/python2.7/site-packages/bcolz/toplevel.pyc in fromiter(iterable, dtype, count, **kwargs)
    193         obj = bcolz.ctable(np.array([], dtype=dtype),
    194                            expectedlen=expectedlen,
--> 195                            **kwargs)
    196         chunklen = sum(obj.cols[name].chunklen
    197                        for name in obj.names) // len(obj.names)

/opt/miniconda/lib/python2.7/site-packages/bcolz/ctable.pyc in __init__(self, columns, names, **kwargs)
    191             if columns is not None and self.mode == 'a':
    192                 raise ValueError(
--> 193                     "You cannot pass a `columns` param in 'a'ppend mode")
    194         else:
    195             self.mode = kwargs.setdefault('mode', 'w')

ValueError: You cannot pass a `columns` param in 'a'ppend mode
```