### PR TITLE
avoid redundant memory copy in chunk.getudata

### DIFF
--- a/bcolz/carray_ext.pyx
+++ b/bcolz/carray_ext.pyx
@@ -78,6 +78,7 @@ from definitions cimport (malloc,
                           PyBytes_AsString,
                           PyBytes_GET_SIZE,
                           PyBytes_FromStringAndSize,
+                          PyBytes_AS_STRING,
                           Py_BEGIN_ALLOW_THREADS,
                           Py_END_ALLOW_THREADS,
                           PyBuffer_FromMemory,
@@ -451,15 +452,14 @@ cdef class chunk:
         cdef int ret
         cdef char *dest
 
-        dest = <char *> malloc(self.nbytes)
-        # Fill dest with uncompressed data
+        result_str = PyBytes_FromStringAndSize(NULL, self.nbytes)
+        dest = PyBytes_AS_STRING(result_str);
+
         ret = blosc_decompress(self.data, dest, self.nbytes)
         if ret < 0:
             raise RuntimeError(
                 "fatal error during Blosc decompression: %d" % ret)
-        string = PyBytes_FromStringAndSize(dest, <Py_ssize_t> self.nbytes)
-        free(dest)
-        return string
+        return result_str
 
     cdef void _getitem(self, int start, int stop, char *dest):
         """Read data from `start` to `stop` and return it as a numpy array."""

--- a/bcolz/definitions.pxd
+++ b/bcolz/definitions.pxd
@@ -62,6 +62,7 @@ cdef extern from "PythonHelper.h":
     object PyBytes_FromString(char *)
     object PyBytes_FromStringAndSize(char *s, int len)
     char *PyBytes_AsString(object string)
+    char *PyBytes_AS_STRING(object string)
     size_t PyBytes_GET_SIZE(object string)
 
     # Functions for lists


### PR DESCRIPTION
Micorbenchmarks to follow.