### PR TITLE
fix bug for incorrect leftover value

### DIFF
--- a/bcolz/carray_ext.pyx
+++ b/bcolz/carray_ext.pyx
@@ -1212,7 +1212,7 @@ cdef class carray:
 
         # Update some counters
         calen = shape[0]  # the length ot the carray
-        self.leftover = (calen % chunklen) * self.atomsize
+        self.leftover = cython.cmod(calen, chunklen) * self.atomsize
         self._cbytes = cbytes
         self._nbytes = calen * self.atomsize
 
@@ -1244,7 +1244,7 @@ cdef class carray:
                            _memory=self._rootdir is None)
             self.chunks.append(chunk_)
             cbytes += chunk_.cbytes
-        self.leftover = leftover = nbytes % self._chunksize
+        self.leftover = leftover = cython.cmod(nbytes, self._chunksize)
         if leftover:
             remainder = array_[nchunks * chunklen:]
             memcpy(self.lastchunk, remainder.data, leftover)
@@ -1432,7 +1432,7 @@ cdef class carray:
                 cbytes += chunk_.cbytes
 
             # Finally, deal with the leftover
-            leftover = nbytes % chunksize
+            leftover = cython.cmod(nbytes, chunksize)
             if leftover:
                 remainder = remainder[nchunks * chunklen:]
                 if arrcpy.strides[0] > 0:
@@ -1488,7 +1488,7 @@ cdef class carray:
         else:
             # nitems larger than last chunk
             nchunk = cython.cdiv((self.len - nitems), self._chunklen)
-            leftover2 = (self.len - nitems) % self._chunklen
+            leftover2 = cython.cmod((self.len - nitems), self._chunklen)
             leftover = leftover2 * atomsize
 
             # Remove complete chunks


### PR DESCRIPTION
In some rare cases using the standard mod operator in cython was causing the leftover value to
be incorrectly set to a non-zero value. This was causing segfaults in bdot (and probably bquery), from attempts to write outside the bounds of correctly sized result arrays in cython.

This example reproduced the bug in my tests.
```python
rows = 2 ** 21
columns = 200
matrix = np.random.random_integers(0, 120, size=(rows, columns))
chunk_len = 2 ** 2
bcarray = bdot.carray(matrix, chunklen=chunk_len, cparams=bdot.cparams(clevel=2))
```

See the 'Abstract' section of this document for details on the differences between standard mod and `cython.cmod`: [Enhancements Division](https://github.com/cython/cython/wiki/enhancements-division)