### PR TITLE
do not assume that `np.array` does the right thing

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -32,7 +32,7 @@ Changes from 0.9.0 to 0.10.0
 - Various refactorings and cleanups. (#190 #198 #197 #199 #200)
 
 - Fix bug creating carrays from transposed arrays without explicit dtype.
-  (#217 @sdvillal)
+  (#217 #218 @sdvillal)
 
 
 Changes from 0.8.1 to 0.9.0

--- a/bcolz/tests/test_carray.py
+++ b/bcolz/tests/test_carray.py
@@ -48,6 +48,29 @@ class initTest(TestCase):
         transposed_array = np.array([[0, 1, 2], [2, 1, 0]]).T
         assert_array_equal(transposed_array, carray(transposed_array, dtype=transposed_array.dtype))
 
+    @unittest.skipIf(not bcolz.pandas_here, "cannot import pandas")
+    def test_roundtrip_from_dataframe1(self):
+        """Testing `__init__` called without `dtype` and a dataframe over non-contiguous data."""
+        import pandas as pd
+        df = pd.DataFrame(data={
+            'a': np.arange(3),
+            'b': np.arange(3)[::-1]
+        })
+        assert_array_equal(df, carray(df, dtype=None))
+
+    @unittest.skipIf(not bcolz.pandas_here, "cannot import pandas")
+    def test_roundtrip_from_dataframe2(self):
+        """Testing `__init__` called with `dtype` and a dataframe over non-contiguous data."""
+        import pandas as pd
+        df = pd.DataFrame(data={
+            'a': np.arange(3),
+            'b': np.arange(3)[::-1]
+        })
+        ca = carray(df, dtype=np.dtype(np.float))
+        assert_array_equal(df, ca)
+        self.assertEqual(ca.dtype, np.dtype(np.float),
+                         msg='carray has been created with invalid dtype')
+
     def test_dtype_None(self):
         """Testing `utils.to_ndarray` called without `dtype` and a non-contiguous (transposed) array."""
         array = np.array([[0, 1, 2], [2, 1, 0]]).T

--- a/bcolz/utils.py
+++ b/bcolz/utils.py
@@ -105,29 +105,29 @@ def to_ndarray(array, dtype, arrlen=None, safe=True):
     if not safe:
         return array
 
-    if not isinstance(array, np.ndarray):
+    if not isinstance(array, np.ndarray) and dtype is None:
         array = np.array(array)
-    if dtype is None:
-        dtype = array.dtype
 
     # Arrays with a 0 stride are special
-    if type(array) == np.ndarray and array.strides[0] == 0:
+    if type(array) == np.ndarray and len(array.strides) and array.strides[0] == 0:
         if array.dtype != dtype.base:
             raise TypeError("dtypes do not match")
         return array
 
     # Ensure that we have an ndarray of the correct dtype
-    if type(array) != np.ndarray or array.dtype != dtype.base:
-        try:
-            array = np.array(array, dtype=dtype.base)
-        except ValueError:
-            raise ValueError("cannot convert to an ndarray object")
+    if dtype is not None:
+        if type(array) != np.ndarray or array.dtype != dtype.base:
+            try:
+                array = np.array(array, dtype=dtype.base)
+            except ValueError:
+                raise ValueError("cannot convert to an ndarray object")
 
     # We need a contiguous array
     if not array.flags.contiguous:
         array = array.copy()
+
+    # We treat scalars like undimensional arrays
     if len(array.shape) == 0:
-        # We treat scalars like undimensional arrays
         array.shape = (1,)
 
     # Check if we need a broadcast

--- a/bcolz/utils.py
+++ b/bcolz/utils.py
@@ -105,9 +105,9 @@ def to_ndarray(array, dtype, arrlen=None, safe=True):
     if not safe:
         return array
 
+    if not isinstance(array, np.ndarray):
+        array = np.array(array)
     if dtype is None:
-        if not isinstance(array, np.ndarray):
-            return np.array(array)
         dtype = array.dtype
 
     # Arrays with a 0 stride are special


### PR DESCRIPTION
Continuation of #217. The fix there only works for transposed arrays, but it still fails to fix errors with, for example, pandas dataframes:

```python
import pandas as pd
import bcolz
df = pd.DataFrame(data={
    'a': np.arange(3),
    'b': np.arange(3)[::-1]
})
print(df)

   a  b
0  0  2
1  1  1
2  2  0

print(bcolz.carray(df))

[[0 1]
 [2 2]
 [1 0]]
```
This is the same example we had in #217, run with latest master (e260ca71bc) installed on latest anaconda. I'm working in a fix for this that will do the right thing (the first commit here is a step, but breaks other conversions).