### PR TITLE
added support for appending np.void in ctables. fixes ticket #229

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -5,7 +5,8 @@ Release notes for bcolz
 Changes from 0.10.0 to 0.11.0
 =============================
 
-- pass
+- Added support for appending a np.void to ctable objects
+  (closes ticket #229 @eumiro)
 
 Changes from 0.9.0 to 0.10.0
 ============================

--- a/bcolz/ctable.py
+++ b/bcolz/ctable.py
@@ -353,6 +353,9 @@ class ctable(object):
                 sclist = True
         elif isinstance(cols, np.ndarray):
             ratype = hasattr(cols.dtype, "names")
+        elif isinstance(cols, np.void):
+            ratype = hasattr(cols.dtype, "names")
+            sclist = True
         elif isinstance(cols, bcolz.ctable):
             # Convert int a list of carrays
             cols = [cols[name] for name in self.names]

--- a/bcolz/tests/test_ctable.py
+++ b/bcolz/tests/test_ctable.py
@@ -671,6 +671,14 @@ class appendTest(MayBeDiskTest):
         ra = np.fromiter(((i, i * 2.) for i in xrange(N + 10)), dtype='i4,f8')
         assert_array_equal(t[:], ra, "ctable values are not correct")
 
+    def test05(self):
+        """Testing append() with void types"""
+        N = 10
+        ra = np.fromiter(((i, i * 2.) for i in xrange(N)), dtype='i4,f8')
+        t = bcolz.ctable(ra[:-1], rootdir=self.rootdir)
+        t.append(ra[-1])
+        assert_array_equal(t[:], ra, "ctable values are not correct")
+
 
 class appendMemoryTest(appendTest, TestCase):
     disk = False


### PR DESCRIPTION
Added a new test for this enhancement.