### PR TITLE
Fe/ci/conda.recipe

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ script:
 
 after_success:
   - coveralls
+  - python continuous-integration/move-conda-package.py conda.recipe
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,31 +1,17 @@
 sudo: false
 language: python
 
-python:
-- 2.6
-- 2.7
-- 3.4
+env:
+  matrix:
+    - python=2.6  CONDA_PY=26  CONDA_NPY=19
+    - python=2.7  CONDA_PY=27  CONDA_NPY=19
+    - python=3.4  CONDA_PY=34  CONDA_NPY=19
 
 install:
-  # Install conda
-  - wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
-  - bash miniconda.sh -b -p $HOME/miniconda
-  - export PATH="$HOME/miniconda/bin:$PATH"
-  - conda config --set always_yes yes --set changeps1 no
-  - conda update conda
-
-  # Install dependencies
-  - conda create -n bcolz_env python=$TRAVIS_PYTHON_VERSION numpy pandas cython nose
-  - source activate bcolz_env
-  - if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then conda install unittest2 mock; fi
-  - if [[ $TRAVIS_PYTHON_VERSION == '2.7' ]]; then conda install mock; fi
-  - pip install coveralls
-  
-  # Build bcolz
-  - python setup.py build_ext --inplace
+  - source continuous-integration/travis/install.sh
 
 script:
-  - nosetests --with-coverage --cover-package bcolz bcolz/tests/test_*.py
+  - conda build conda.recipe --quiet
 
 after_success:
   - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ install:
   - source continuous-integration/travis/install.sh
 
 script:
+  - conda config --add channels elies
   - conda build conda.recipe --quiet
 
 after_success:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -64,7 +64,7 @@ test_script:
   # doesn't really work.
   #
   - "%CMD_IN_ENV% conda config --add channels elies"
-  - "%CMD_IN_ENV% conda build conda.recipe --quiet"
+  - "%CMD_IN_ENV% conda build conda.recipe "
   # Move the conda package into the current directory, to register it
   # as an "artifact" for Appveyor. cmd.exe does't have good globbing, so
   # we'll use a simple python script.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -63,8 +63,5 @@ test_script:
   # is set dynamically. This unfortunately mean that conda build --output
   # doesn't really work.
   #
-    - "%CMD_IN_ENV% conda install --yes --quiet cython pandas mock"
+  - "%CMD_IN_ENV% conda build conda.recipe --quiet"
 
-  # Build the compiled extension and run the project tests
-    - "%CMD_IN_ENV% python setup.py build_ext --inplace"
-    - "%CMD_IN_ENV% python -c \"import bcolz; bcolz.test(heavy=True)\""

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -63,6 +63,7 @@ test_script:
   # is set dynamically. This unfortunately mean that conda build --output
   # doesn't really work.
   #
+  - "%CMD_IN_ENV% conda config --add channels elies"
   - "%CMD_IN_ENV% conda build conda.recipe --quiet"
   # Move the conda package into the current directory, to register it
   # as an "artifact" for Appveyor. cmd.exe does't have good globbing, so

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -64,4 +64,11 @@ test_script:
   # doesn't really work.
   #
   - "%CMD_IN_ENV% conda build conda.recipe --quiet"
+  # Move the conda package into the current directory, to register it
+  # as an "artifact" for Appveyor. cmd.exe does't have good globbing, so
+  # we'll use a simple python script.
+  - python continuous-integration\move-conda-package.py conda.recipe
 
+artifacts:
+  # Archive the generated conda package in the ci.appveyor.com build report.
+  - path: '*.tar.bz2'

--- a/conda.recipe/bld.bat
+++ b/conda.recipe/bld.bat
@@ -1,6 +1,5 @@
 xcopy /e "%RECIPE_DIR%\.." "%SRC_DIR%"
 SET BLD_DIR=%CD%
 cd /D "%RECIPE_DIR%\.."
-FOR /F "delims=" %%i IN ('git describe --tags') DO set BCOLZ_VERSION=%%i
-echo.%BCOLZ_VERSION% | %PYTHON% .\conda.recipe\version.py > %SRC_DIR%\__conda_version__.txt
+copy "%SRC_DIR%\VERSION" "%SRC_DIR%\__conda_version__.txt"
 %PYTHON% setup.py --quiet install

--- a/conda.recipe/build.sh
+++ b/conda.recipe/build.sh
@@ -7,7 +7,7 @@ SRC_DIR=$RECIPE_DIR/..
 pushd $SRC_DIR
 
 # X.X.X.dev builds
-u_version=`git describe --tags | $PYTHON $SRC_DIR/conda.recipe/version.py`
+u_version=`git describe --tags | sed 's/-.*//' | $PYTHON $SRC_DIR/conda.recipe/version.py`
 
 echo $u_version > __conda_version__.txt
 

--- a/conda.recipe/build.sh
+++ b/conda.recipe/build.sh
@@ -7,7 +7,7 @@ SRC_DIR=$RECIPE_DIR/..
 pushd $SRC_DIR
 
 # X.X.X.dev builds
-u_version=`git describe --tags | sed 's/-.*//' | $PYTHON $SRC_DIR/conda.recipe/version.py`
+u_version=`git describe --tags | sed 's/-.*//'`
 
 echo $u_version > __conda_version__.txt
 

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -1,6 +1,10 @@
 package:
   name: bcolz 
 
+source:
+    git_rev: v1.7.0
+    git_url: https://github.com/pypa/setuptools_scm.git
+
 requirements:
   build:
     - python

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -11,7 +11,7 @@ build:
 requirements:
   build:
     - python
-    - setuptools_scm 
+    - setuptools-scm 
     - cython
     - numpy
 

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -11,7 +11,7 @@ build:
 requirements:
   build:
     - python
-    - setuptools-scm 
+    - setuptools_scm 
     - cython
     - numpy
 

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -1,10 +1,6 @@
 package:
   name: bcolz 
 
-source:
-    git_rev: v1.7.0
-    git_url: https://github.com/pypa/setuptools_scm.git
-
 build:
     preserve_egg_dir: True
 

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -1,16 +1,11 @@
 package:
   name: bcolz 
-  version: "0.7.2"
-
-build:
-    number: {{environ.get('BINSTAR_BUILD', 1)}}
 
 requirements:
   build:
     - python
     - cython
     - numpy
-    - unittest2 [py26]
 
   run:
     - python
@@ -19,6 +14,9 @@ requirements:
 test:
   requires:
     - unittest2 [py26]
+    - mock [py2k]
+    - pandas
+
   commands:
     - python -c "import bcolz; bcolz.test()"
 

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -1,8 +1,6 @@
 package:
   name: bcolz 
 
-build:
-    preserve_egg_dir: True
 
 requirements:
   build:

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -5,6 +5,9 @@ source:
     git_rev: v1.7.0
     git_url: https://github.com/pypa/setuptools_scm.git
 
+build:
+    preserve_egg_dir: True
+
 requirements:
   build:
     - python

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -11,6 +11,7 @@ build:
 requirements:
   build:
     - python
+    - setuptools_scm 
     - cython
     - numpy
 

--- a/continuous-integration/move-conda-package.py
+++ b/continuous-integration/move-conda-package.py
@@ -1,0 +1,14 @@
+import sys
+import os
+import yaml
+import glob
+import shutil
+from conda_build import config
+
+with open(os.path.join(sys.argv[1], 'meta.yaml')) as f:
+    name = yaml.load(f)['package']['name']
+
+binary_package_glob = os.path.join(config.bldpkgs_dir, '{0}*.tar.bz2'.format(name))
+binary_package = glob.glob(binary_package_glob)[0]
+
+shutil.move(binary_package, '.')

--- a/continuous-integration/travis/install.sh
+++ b/continuous-integration/travis/install.sh
@@ -1,0 +1,9 @@
+MINICONDA_URL="http://repo.continuum.io/miniconda"
+MINICONDA_FILE="Miniconda-3.5.5-Linux-x86_64.sh"
+wget "${MINICONDA_URL}/${MINICONDA_FILE}"
+bash $MINICONDA_FILE -b
+
+export PATH=$HOME/miniconda/bin:$PATH
+
+conda update --yes conda
+conda install --yes pip conda-build jinja2 binstar

--- a/continuous-integration/travis/install.sh
+++ b/continuous-integration/travis/install.sh
@@ -1,5 +1,5 @@
 MINICONDA_URL="http://repo.continuum.io/miniconda"
-MINICONDA_FILE="Miniconda-3.5.5-Linux-x86_64.sh"
+MINICONDA_FILE="Miniconda-latest-Linux-x86_64.sh"
 wget "${MINICONDA_URL}/${MINICONDA_FILE}"
 bash $MINICONDA_FILE -b
 


### PR DESCRIPTION
This PR offers the follwoing for CI travis and appveyor:
- Instead of managing dependencies for both CI systems separately, uses `meta.yaml` as a centralised file.
- Fix: `CONDA_NPY: "1.9"` to `CONDA_NPY: "19"`
- Move Package to make the CI aware of created artifacts, see e.g. https://ci.appveyor.com/project/FrancescElies/bcolz/build/job/gjfo47pewpekocwo/artifacts
- Modifies `conda.recipe/bld.bat ` and `conda.recipe/build.sh`, I doubt if I did the right thing here, but I could not make it work without modifying them, would you be OK with these modifications?

Based on https://github.com/rmcgibbo/python-appveyor-conda-example/

Thanks in advance for the time you invest reviewing this.