### PR TITLE
Provide a better error when opening a ctable for read with a nonexistent rootdir.

### DIFF
--- a/bcolz/ctable.py
+++ b/bcolz/ctable.py
@@ -309,7 +309,12 @@ class ctable(object):
     def open_ctable(self):
         """Open an existing ctable on-disk."""
         if self.mode == 'r' and not os.path.exists(self.rootdir):
-            raise KeyError("Disk-based ctable opened with `r`ead mode yet `rootdir` does not exist")
+            raise KeyError(
+                "Disk-based ctable opened with `r`ead mode "
+                "yet `rootdir='{rootdir}'` does not exist".format(
+                    rootdir=self.rootdir,
+                )
+            )
 
         # Open the ctable by reading the metadata
         self.cols.read_meta_and_open()

--- a/bcolz/tests/test_ctable.py
+++ b/bcolz/tests/test_ctable.py
@@ -18,7 +18,6 @@ from bcolz.tests.common import MayBeDiskTest, TestCase, unittest, skipUnless
 import bcolz
 from bcolz.py2help import xrange, PY2, Mock
 import pickle
-import os
 
 
 class createTest(MayBeDiskTest):

--- a/bcolz/tests/test_ctable.py
+++ b/bcolz/tests/test_ctable.py
@@ -232,8 +232,9 @@ class persistentTest(MayBeDiskTest, TestCase):
             )
         )
 
-        with self.assertRaisesRegexp(KeyError, expected_message):
+        with self.assertRaises(KeyError) as ctx:
             bcolz.ctable(rootdir=non_existent_root, mode='r')
+        self.assertEqual(ctx.exception.message, expected_message)
 
 
 class add_del_colTest(MayBeDiskTest):

--- a/bcolz/tests/test_ctable.py
+++ b/bcolz/tests/test_ctable.py
@@ -234,7 +234,7 @@ class persistentTest(MayBeDiskTest, TestCase):
 
         with self.assertRaises(KeyError) as ctx:
             bcolz.ctable(rootdir=non_existent_root, mode='r')
-        self.assertEqual(ctx.exception.message, expected_message)
+        self.assertEqual(ctx.exception.args[0], expected_message)
 
 
 class add_del_colTest(MayBeDiskTest):

--- a/bcolz/tests/test_ctable.py
+++ b/bcolz/tests/test_ctable.py
@@ -221,6 +221,20 @@ class persistentTest(MayBeDiskTest, TestCase):
         ra = np.rec.fromarrays([a[:], b[:]]).view(np.ndarray)
         assert_array_equal(t[:], ra, "ctable values are not correct")
 
+    def test01d(self):
+        """Testing ctable opening in "r" mode with nonexistent directory"""
+        tempdir = tempfile.mkdtemp(prefix='bcolz-test01d')
+        non_existent_root = os.path.join(tempdir, 'not/a/real/path')
+        expected_message = (
+            "Disk-based ctable opened with `r`ead mode "
+            "yet `rootdir='{rootdir}'` does not exist".format(
+                rootdir=non_existent_root,
+            )
+        )
+
+        with self.assertRaisesRegexp(KeyError, expected_message):
+            bcolz.ctable(rootdir=non_existent_root, mode='r')
+
 
 class add_del_colTest(MayBeDiskTest):
 


### PR DESCRIPTION
When directly invoking the `ctable` constructor with a rootdir and and mode = 'r', the following error gets raised:

```
In [1]: from bcolz import ctable

In [2]: ctable(rootdir='/not/real/', mode='r')
---------------------------------------------------------------------------
KeyError                                  Traceback (most recent call last)
<ipython-input-2-d959ad9bc242> in <module>()
----> 1 ctable(rootdir='/not/real/', mode='r')

/home/ssanderson/clones/bcolz/bcolz/ctable.py in __init__(self, columns, names, **kwargs)
    219         _new = False
    220         if self.mode in ('r', 'a'):
--> 221             self.open_ctable()
    222         elif columns is not None:
    223             self.create_ctable(columns, names, **kwargs)

/home/ssanderson/clones/bcolz/bcolz/ctable.py in open_ctable(self)
    310         """Open an existing ctable on-disk."""
    311         if self.mode == 'r' and not os.path.exists(self.rootdir):
--> 312             raise KeyError("Disk-based ctable opened with `r`ead mode yet `rootdir` does not exist")
    313
    314         # Open the ctable by reading the metadata

KeyError: 'Disk-based ctable opened with `r`ead mode yet `rootdir` does not exist'
```
This is a largely unhelpful error, since the piece of information most likely to help me fix the problem is the non-existent rootdir I tried to open.

This PR amends the thrown error message to include more contextual information.  It now instead reads:
```
In [2]: ctable(rootdir='/not/real/', mode='r')
---------------------------------------------------------------------------
KeyError                                  Traceback (most recent call last)
<ipython-input-2-d959ad9bc242> in <module>()
----> 1 ctable(rootdir='/not/real/', mode='r')

/home/ssanderson/clones/bcolz/bcolz/ctable.py in __init__(self, columns, names, **kwargs)
    219         _new = False
    220         if self.mode in ('r', 'a'):
--> 221             self.open_ctable()
    222         elif columns is not None:
    223             self.create_ctable(columns, names, **kwargs)

/home/ssanderson/clones/bcolz/bcolz/ctable.py in open_ctable(self)
    313                 "Disk-based ctable opened with `r`ead mode "
    314                 "yet `rootdir='{rootdir}'` does not exist".format(
--> 315                     rootdir=self.rootdir,
    316                 )
    317             )

KeyError: "Disk-based ctable opened with `r`ead mode yet `rootdir='/not/real/'` does not exist"
```