### PR TITLE
Fe/asv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,8 @@ bcolz/version.py
 
 *.pyd
 bcolz.egg-info/
+
+# airspeed velocity
+env
+results
+project

--- a/README.rst
+++ b/README.rst
@@ -5,6 +5,7 @@ bcolz: columnar and compressed data containers
 :Travis CI: |travis|
 :Appveyor: |appveyor|
 :Coveralls: |coveralls|
+:Airspeed Velocity: |asv|
 :And...: |powered|
 
 .. |version| image:: https://img.shields.io/pypi/v/bcolz.png
@@ -21,6 +22,9 @@ bcolz: columnar and compressed data containers
 
 .. |coveralls| image:: https://coveralls.io/repos/Blosc/bcolz/badge.png
         :target: https://coveralls.io/r/Blosc/bcolz
+
+.. |asv| image:: http://img.shields.io/badge/benchmarked%20by-asv-green.svg?style=flat
+        :target: http://your-url-here
 
 bcolz provides columnar, chunked data containers that can be
 compressed either in-memory and on-disk.  Column storage allows for

--- a/asv.conf.json
+++ b/asv.conf.json
@@ -1,0 +1,76 @@
+{
+    // The version of the config file format.  Do not change, unless
+    // you know what you are doing.
+    "version": 1,
+
+    // The name of the project being benchmarked
+    "project": "bcolz",
+
+    // The project's homepage
+    "project_url": "https://github.com/Blosc/bcolz",
+
+    // The URL or local path of the source code repository for the
+    // project being benchmarked
+    "repo": "https://github.com/Blosc/bcolz.git",
+
+    // List of branches to benchmark. If not provided, defaults to "master"
+    // (for git) or "tip" (for mercurial).
+    // "branches": ["master"], // for git
+    // "branches": ["tip"],    // for mercurial
+
+    // The DVCS being used.  If not set, it will be automatically
+    // determined from "repo" by looking at the protocol in the URL
+    // (if remote), or by looking for special directories, such as
+    // ".git" (if local).
+    // "dvcs": "git",
+
+    // The tool to use to create environments.  May be "conda",
+    // "virtualenv" or other value depending on the plugins in use.
+    // If missing or the empty string, the tool will be automatically
+    // determined by looking for tools on the PATH environment
+    // variable.
+    "environment_type": "conda",
+
+    // the base URL to show a commit for the project.
+    "show_commit_url": "http://github.com/blosc/bcolz/commit/",
+
+    // The Pythons you'd like to test against.  If not provided, defaults
+    // to the current version of Python used to run `asv`.
+    "pythons": ["2.7"],
+
+    // The matrix of dependencies to test.  Each key is the name of a
+    // package (in PyPI) and the values are version numbers.  An empty
+    // list indicates to just test against the default (latest)
+    // version.
+    "matrix": {
+        "numpy": [],
+        "pandas": [],
+        "numexpr": [],
+        "cython": [],
+    },
+
+    // The directory (relative to the current directory) that benchmarks are
+    // stored in.  If not provided, defaults to "benchmarks"
+    "benchmark_dir": "bench_asv",
+
+    // The directory (relative to the current directory) to cache the Python
+    // environments in.  If not provided, defaults to "env"
+    // "env_dir": "env",
+
+
+    // The directory (relative to the current directory) that raw benchmark
+    // results are stored in.  If not provided, defaults to "results".
+    // "results_dir": "results",
+
+    // The directory (relative to the current directory) that the html tree
+    // should be written to.  If not provided, defaults to "html".
+    // "html_dir": "html",
+
+    // The number of characters to retain in the commit hashes.
+    // "hash_length": 8,
+
+    // `asv` will cache wheels of the recent builds in each
+    // environment, making them faster to install next time.  This is
+    // number of builds to keep, per environment.
+    // "wheel_cache_size": 0
+}

--- a/bcolz/py2help.py
+++ b/bcolz/py2help.py
@@ -97,9 +97,3 @@ else:
                 raise CalledProcessError(retcode, cmd)
         return output
 
-
-if sys.version[0:3] >= '3.3':
-    from unittest.mock import Mock
-else:
-    from mock import Mock
-Mock = Mock

--- a/bcolz/py2help_tests.py
+++ b/bcolz/py2help_tests.py
@@ -1,0 +1,7 @@
+import sys
+
+if sys.version[0:3] >= '3.3':
+    from unittest.mock import Mock
+else:
+    from mock import Mock
+Mock = Mock

--- a/bcolz/tests/test_ctable.py
+++ b/bcolz/tests/test_ctable.py
@@ -17,7 +17,8 @@ from numpy.testing import assert_array_equal, assert_allclose
 from bcolz.tests.common import (
         MayBeDiskTest, TestCase, unittest, skipUnless, SkipTest ) 
 import bcolz
-from bcolz.py2help import xrange, PY2, Mock
+from bcolz.py2help import xrange, PY2
+from bcolz.py2help_tests import Mock
 import pickle
 
 

--- a/bench_asv/README_asv.md
+++ b/bench_asv/README_asv.md
@@ -1,0 +1,21 @@
+Airspeed velocity
+=================
+
+```
+asv run
+```
+
+Preview results
+---------------
+```
+asv publish
+asv preview
+firefox  http://127.0.0.1:8080/
+```
+
+Upload results to github pages
+------------------------------
+```
+asv gh-pages
+visit http://<your_githhub_username>.github.io/bcolz/
+```

--- a/bench_asv/README_asv.md
+++ b/bench_asv/README_asv.md
@@ -1,9 +1,10 @@
 Airspeed velocity
 =================
-
-```
-asv run
-```
+For more information how to run it please visit
+http://asv.readthedocs.org/en/latest/using.html
+Some examples:
+`asv run`
+`asv run --skip-existing-commits -s 10 ALL`
 
 Preview results
 ---------------

--- a/bench_asv/arange.py
+++ b/bench_asv/arange.py
@@ -1,7 +1,10 @@
 import numpy as np
 import bcolz
+from .bench_helper import ctime
+
 
 class Suite:
+
     def setup(self):
         self.N = 1e8
         self.dtype = 'i4'
@@ -13,3 +16,8 @@ class Suite:
     def time_arange(self):
         ac = bcolz.arange(self.start, self.stop, self.step, dtype=self.dtype)
 
+if __name__ == '__main__':
+    suite = Suite()
+    suite.setup()
+    with ctime("time_arange"):
+        suite.time_arange()

--- a/bench_asv/arange.py
+++ b/bench_asv/arange.py
@@ -1,0 +1,15 @@
+import numpy as np
+import bcolz
+
+class Suite:
+    def setup(self):
+        self.N = 1e8
+        self.dtype = 'i4'
+        self.start = 5
+        self.stop = self.N
+        self.step = 4
+        self.a = np.arange(self.start, self.stop, self.step, dtype=self.dtype)
+
+    def time_arange(self):
+        ac = bcolz.arange(self.start, self.stop, self.step, dtype=self.dtype)
+

--- a/bench_asv/bench_helper.py
+++ b/bench_asv/bench_helper.py
@@ -1,0 +1,11 @@
+from __future__ import print_function
+import contextlib
+import time
+
+
+@contextlib.contextmanager
+def ctime(label=""):
+    "Counts the time spent in some context"
+    t = time.time()
+    yield
+    print(label, round(time.time() - t, 3), "sec")

--- a/bench_asv/column_iter.py
+++ b/bench_asv/column_iter.py
@@ -1,18 +1,23 @@
-import bcolz, numpy
+import bcolz
+import numpy
+from .bench_helper import ctime
 
 N = 1000 * 1000
 
-ct = bcolz.fromiter(((i, i*i, i*i*i) for i in xrange(N)), dtype='i8,i8,i8', count=N)
+ct = bcolz.fromiter(((i, i * i, i * i * i)
+                     for i in xrange(N)), dtype='i8,i8,i8', count=N)
 
 b = numpy.array(numpy.arange(N) % 2, dtype="bool")
 c = bcolz.carray(b)
 
 sorted_index = range(1, N, 2)
 
+
 class Suite:
+
     def time_tolist(self):
         return (ct['f0'][sorted_index]).tolist()
-    
+
     def time_where_01(self):
         return [x.f0 for x in ct.where(b)]
 
@@ -33,12 +38,37 @@ class Suite:
 
     def time_sum_03(self):
         return bcolz.fromiter((x for x in ct['f0'].where(c)),
-                dtype=ct['f0'].dtype, count=c.wheretrue().sum()).sum()
+                              dtype=ct['f0'].dtype, count=c.wheretrue().sum()).sum()
 
     def time_sum_na_01(self):
         # sum with no NA's
-        return sum([x for x in ct['f0'].where(c) if x == x])  # x==x check to leave out NA values
+        # x==x check to leave out NA values
+        return sum([x for x in ct['f0'].where(c) if x == x])
 
     def time_sum_na_02(self):
         # sum with no NA's
-        return sum((x for x in ct['f0'].where(c) if x == x))  # x==x check to leave out NA values
+        # x==x check to leave out NA values
+        return sum((x for x in ct['f0'].where(c) if x == x))
+
+if __name__ == '__main__':
+    s = Suite()
+    with ctime("time_sum_01"):
+        s.time_sum_01()
+    with ctime("time_sum_02"):
+        s.time_sum_02()
+    with ctime("time_sum_03"):
+        s.time_sum_03()
+    with ctime("time_sum_na_01"):
+        s.time_sum_na_01()
+    with ctime("time_sum_na_02"):
+        s.time_sum_na_02()
+    with ctime("time_tolist"):
+        s.time_tolist()
+    with ctime("time_where_01"):
+        s.time_where_01()
+    with ctime("time_where_02"):
+        s.time_where_02()
+    with ctime("time_where_03"):
+        s.time_where_03()
+    with ctime("time_where_04"):
+        s.time_where_04()

--- a/bench_asv/column_iter.py
+++ b/bench_asv/column_iter.py
@@ -1,0 +1,44 @@
+import bcolz, numpy
+
+N = 1000 * 1000
+
+ct = bcolz.fromiter(((i, i*i, i*i*i) for i in xrange(N)), dtype='i8,i8,i8', count=N)
+
+b = numpy.array(numpy.arange(N) % 2, dtype="bool")
+c = bcolz.carray(b)
+
+sorted_index = range(1, N, 2)
+
+class Suite:
+    def time_tolist(self):
+        return (ct['f0'][sorted_index]).tolist()
+    
+    def time_where_01(self):
+        return [x.f0 for x in ct.where(b)]
+
+    def time_where_02(self):
+        return [x.f0 for x in ct.where(c)]
+
+    def time_where_03(self):
+        return [x for x in ct['f0'].where(b)]
+
+    def time_where_04(self):
+        return [x for x in ct['f0'].where(c)]
+
+    def time_sum_01(self):
+        return sum([x for x in ct['f0'].where(c)])
+
+    def time_sum_02(self):
+        return sum(x for x in ct['f0'].where(c))
+
+    def time_sum_03(self):
+        return bcolz.fromiter((x for x in ct['f0'].where(c)),
+                dtype=ct['f0'].dtype, count=c.wheretrue().sum()).sum()
+
+    def time_sum_na_01(self):
+        # sum with no NA's
+        return sum([x for x in ct['f0'].where(c) if x == x])  # x==x check to leave out NA values
+
+    def time_sum_na_02(self):
+        # sum with no NA's
+        return sum((x for x in ct['f0'].where(c) if x == x))  # x==x check to leave out NA values

--- a/bench_asv/concat.py
+++ b/bench_asv/concat.py
@@ -1,0 +1,108 @@
+# Benchmark that compares the times for concatenating arrays with
+# compressed arrays vs plain numpy arrays.  The 'numpy' and 'concat'
+# styles are for regular numpy arrays, while 'carray' is for carrays.
+#
+# Call this benchmark as:
+#
+# python bench/concat.py style
+#
+# where `style` can be any of 'numpy', 'concat' or 'bcolsz'
+#
+# You can modify other parameters from the command line if you want:
+#
+# python bench/concat.py style arraysize nchunks nrepeats clevel
+#
+
+from __future__ import absolute_import
+
+import sys
+import math
+import time
+
+import numpy
+
+import bcolz
+from bcolz.py2help import xrange
+
+
+def concat(data):
+    tlen = sum(x.shape[0] for x in data)
+    alldata = numpy.empty((tlen,))
+    pos = 0
+    for x in data:
+        step = x.shape[0]
+        alldata[pos:pos + step] = x
+        pos += step
+
+    return alldata
+
+
+def append(data, clevel):
+    alldata = bcolz.carray(data[0], cparams=bcolz.cparams(clevel))
+    for carr in data[1:]:
+        alldata.append(carr)
+
+    return alldata
+
+class Suite:
+    a = None
+    N = 1000000
+    K = 10
+    T = 3
+    clevel = 1
+    style = 'bcolz'
+
+    def __init__(self, N=1000000, K=10, T=3, clevel=1, style='bcolz'):
+        Suite.N = N
+        Suite.K = K
+        Suite.T = T
+        Suite.clevel = clevel
+        Suite.style = style
+
+    def setup(self):
+        # The next datasets allow for very high compression ratios
+        Suite.a = [numpy.arange(Suite.N, dtype='f8') for _ in range(Suite.K)]
+        print("problem size: (%d) x %d = 10^%g" % (Suite.N, Suite.K, 
+            math.log10(Suite.N * Suite.K)))
+    
+    def time_concatenate(self):
+        t = time.time()
+        if Suite.style == 'numpy':
+            for _ in xrange(Suite.T):
+                r = numpy.concatenate(Suite.a, 0)
+        elif Suite.style == 'concat':
+            for _ in xrange(Suite.T):
+                r = concat(Suite.a)
+        elif Suite.style == 'bcolz':
+            for _ in xrange(Suite.T):
+                r = append(Suite.a, Suite.clevel)
+
+        t = time.time() - t
+        print('time for concat: %.3fs' % (t / Suite.T))
+
+        if Suite.style == 'bcolz':
+            size = r.cbytes
+        else:
+            size = r.size * r.dtype.itemsize
+        print("size of the final container: %.3f MB" % (size / float(1024 * 1024)) )
+
+
+if __name__ == '__main__':
+    if len(sys.argv) < 2:
+        print("Pass at least one of these styles: 'numpy', 'concat' or 'bcolz' ")
+        sys.exit(1)
+
+    style = sys.argv[1]
+    if len(sys.argv) == 2:
+        N, K, T, clevel = (1000000, 10, 3, 1)
+    else:
+        N, K, T = [int(arg) for arg in sys.argv[2:5]]
+        if len(sys.argv) > 5:
+            clevel = int(sys.argv[5])
+        else:
+            clevel = 0
+
+    # run benchmark
+    suite = Suite(N=N, K=K, T=T, clevel=clevel, style=style)
+    suite.setup()
+    suite.time_concatenate()


### PR DESCRIPTION
In case still interested, maybe first steps towards https://github.com/Blosc/bcolz/issues/116?

Modifications:
- Basic config file  `asv.conf.json`
- Added a small guide at `bench/README_asv.md`.
- Benchmarks would need some extra boilerplate (see  `bench/arange.py`, `bench/column_iter.py`) and _maybe some renaming asv does not like dashes (-)_.
- Modified benchmarks respect `run.sh` (they still could be ran with this script).
- Benchmarks for Python 3 not working, not sure why.

Running it:
- For the moment to get it running only adapted scripts should show up in the `bench` folder (run first `rm -f bench/*` and `git checkout bench/arange.py bench/column_iter.py bench/__init__.py`)
- Preview available at http://francescelies.github.io/bcolz/ (only some points can be seen, but if desired one could ran it for every commit in the repository, would take a while though).