### PR TITLE
fix: asv gets confused with `bcolz` project name

### DIFF
--- a/asv.conf.json
+++ b/asv.conf.json
@@ -4,7 +4,7 @@
     "version": 1,
 
     // The name of the project being benchmarked
-    "project": "bcolz",
+    "project": "_bcolz", // underscore is intentional
 
     // The project's homepage
     "project_url": "https://github.com/Blosc/bcolz",


### PR DESCRIPTION
@FrancescAlted this should fix https://github.com/Blosc/bcolz/pull/253#issuecomment-145458834
Could you please give it a try