### PR TITLE
Py2strings

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -23,6 +23,9 @@ Changes from 0.11.4 to 0.12.0
   assignments.  Fixes a VisibleDeprecationWarning with NumPy 1.10
   (@FrancescAlted).
 
+- More consistent string-type checking to allow use of unicode strings
+  in Python 2 for queries, column selection, etc. (#274 @BrenBarn)
+
 
 Changes from 0.11.3 to 0.11.4
 =============================

--- a/bcolz/ctable.py
+++ b/bcolz/ctable.py
@@ -385,7 +385,7 @@ class ctable(object):
             if sclist and not hasattr(column, '__len__'):
                 clen2 = 1
             else:
-                if isinstance(column, _strtypes + (bytes,)):
+                if isinstance(column, _strtypes):
                     clen2 = 1
                 else:
                     clen2 = len(column)
@@ -472,7 +472,7 @@ class ctable(object):
         if name is None:
             name = "f%d" % pos
         else:
-            if type(name) != str:
+            if not isinstance(name, _strtypes):
                 raise ValueError("`name` must be a string")
         if name in self.names:
             raise ValueError("'%s' column already exists" % name)
@@ -539,7 +539,7 @@ class ctable(object):
         if name is not None and pos is not None:
             raise ValueError("you cannot specify both a `name` and a `pos`")
         if name:
-            if type(name) != str:
+            if not isinstance(name, _strtypes):
                 raise ValueError("`name` must be a string")
             if name not in self.names:
                 raise ValueError("`name` not found in columns")
@@ -847,7 +847,7 @@ class ctable(object):
         """
 
         # Check input
-        if isinstance(expression, (bytes, str)):
+        if isinstance(expression, _strtypes):
             # That must be an expression
             boolarr = self.eval(expression)
         elif hasattr(expression, "dtype") and expression.dtype.kind == 'b':
@@ -860,7 +860,7 @@ class ctable(object):
         if outcols is None:
             outcols = self.names
         else:
-            if type(outcols) not in (list, tuple, bytes, str):
+            if type(outcols) not in (list, tuple) + _strtypes:
                 raise ValueError("only list/str is supported for outcols")
             # Check name validity
             nt = namedtuple('_nt', outcols, verbose=False)
@@ -985,7 +985,7 @@ class ctable(object):
         if outcols is None:
             outcols = self.names
         else:
-            if type(outcols) not in (list, tuple, str):
+            if type(outcols) not in (list, tuple) + _strtypes:
                 raise ValueError("only list/str is supported for outcols")
             # Check name validity
             nt = namedtuple('_nt', outcols, verbose=False)
@@ -1080,7 +1080,7 @@ class ctable(object):
         elif type(key) is list:
             if len(key) == 0:
                 return np.empty(0, self.dtype)
-            strlist = all(isinstance(v, str) for v in key)
+            strlist = all(isinstance(v, _strtypes) for v in key)
             # Range of column names
             if strlist:
                 cols = [self.cols[name] for name in key]

--- a/bcolz/py2help.py
+++ b/bcolz/py2help.py
@@ -58,7 +58,7 @@ else:
     xrange = range
     izip = zip
     _inttypes = (int,)
-    _strtypes = (str,)
+    _strtypes = (bytes, str)
     unicode = str
     imap = map
     basestring = str

--- a/bcolz/tests/test_ctable.py
+++ b/bcolz/tests/test_ctable.py
@@ -608,6 +608,33 @@ class getitemTest(MayBeDiskTest):
         assert_array_equal(t[:], ra[:],
                            "ctable values are not correct")
 
+    def test_unicode_colname(self):
+        """Testing __getitem__ with a unicode column name"""
+        N = 10
+        ra = np.fromiter(((i, i * 2.) for i in xrange(N)), dtype='i4,f8')
+        t = bcolz.ctable(ra, rootdir=self.rootdir)
+        colname = u"f1"
+        # print "t->", `t[colname]`
+        # print "ra->", ra[colname]
+        assert_array_equal(t[colname][:], ra[colname],
+                           "ctable values are not correct")                          
+
+    def test_multi_unicode_colnames(self):
+        """Testing __getitem__ with a list of unicode column names"""
+        N = 10
+        ra = np.fromiter(((i, i * 2., i * 3)
+                          for i in xrange(N)), dtype='i4,f8,i8')
+        t = bcolz.ctable(ra, rootdir=self.rootdir)
+        colnames = [u"f0", u"f2"]
+        # For some version of NumPy (> 1.7) I cannot make use of
+        # ra[colnames]   :-/
+        ra2 = np.fromiter(((i, i * 3) for i in xrange(N)), dtype='i4,i8')
+        ra2.dtype.names = ('f0', 'f2')
+        # print "t->", `t[colnames]`
+        # print "ra2->", ra2
+        assert_array_equal(t[colnames][:], ra2,
+                           "ctable values are not correct")
+
 
 class getitemMemoryTest(getitemTest, TestCase):
     disk = False

--- a/bcolz/tests/test_queries.py
+++ b/bcolz/tests/test_queries.py
@@ -235,6 +235,12 @@ class stringTest(TestCase):
             "STATE == b'California'", outcols=["nrow__", "b"])]
         self.assertTrue(res == [(0, 1)],
                         "querying strings not working correctly")
+        # test with unicode
+        res = [tuple(row) for row in t.where(
+            u"STATE == b'California'", outcols=["nrow__", "b"])]
+        self.assertTrue(res == [(0, 1)],
+                        "querying strings not working correctly with unicode querystring")
+
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This fixes up string-type handling in a few places.  Bcolz has a py2helper module for aiding Python 2/3 compatibility, but wasn't using it in several places.  This results in problems when using bcolz with Python 2 for various tasks (e.g., selecting multiple columns whose names are given as unicode strings, see also #272 ).

I wrote a couple tests to test unicode handling, and everything is passing on Py2, but I'm not set up right now to test bcolz on Python 3, so hopefully someone else (like maybe the helpful Mr. Travis) can check that.