### PR TITLE
BLD: Defer numpy/Cython operations in setup.py.

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -6,6 +6,10 @@ Changes from 0.12.0 to 0.12.1
 =============================
 
 #XXX version-specific blurb XXX#
+- ``setup.py`` now defers operations requiring ``numpy`` and ``Cython``
+  until after those modules have been installed by ``setuptools``.  This
+  means that users no longer need to pre-install ``numpy`` and
+  ``Cython`` to install ``bcolz``.
 
 
 Changes from 0.11.4 to 0.12.0

--- a/setup.py
+++ b/setup.py
@@ -22,8 +22,55 @@ import sys
 import re
 
 from setuptools import setup, Extension, find_packages
+from pkg_resources import resource_filename
 
-import numpy
+
+class LazyCommandClass(dict):
+    """
+    Lazy command class that defers operations requiring Cython and numpy until
+    they've actually been downloaded and installed by setup_requires.
+    """
+    def __contains__(self, key):
+        return (
+            key == 'build_ext'
+            or super(LazyCommandClass, self).__contains__(key)
+        )
+
+    def __setitem__(self, key, value):
+        if key == 'build_ext':
+            raise AssertionError("build_ext overridden!")
+        super(LazyCommandClass, self).__setitem__(key, value)
+
+    def __getitem__(self, key):
+        if key != 'build_ext':
+            return super(LazyCommandClass, self).__getitem__(key)
+
+        from Cython.Distutils import build_ext as cython_build_ext
+
+        class build_ext(cython_build_ext):
+            """
+            Custom build_ext command that lazily adds numpy's include_dir to
+            extensions.
+            """
+            def build_extensions(self):
+                """
+                Lazily append numpy's include directory to Extension includes.
+
+                This is done here rather than at module scope because setup.py
+                may be run before numpy has been installed, in which case
+                importing numpy and calling `numpy.get_include()` will fail.
+                """
+                numpy_incl = resource_filename('numpy', 'core/include')
+                for ext in self.extensions:
+                    ext.include_dirs.append(numpy_incl)
+
+                # This explicitly calls the superclass method rather than the
+                # usual super() invocation because distutils' build_class, of
+                # which Cython's build_ext is a subclass, is an old-style class
+                # in Python 2, which doesn't support `super`.
+                cython_build_ext.build_extensions(self)
+        return build_ext
+
 
 # Global variables
 CFLAGS = os.environ.get('CFLAGS', '').split()
@@ -32,7 +79,7 @@ LFLAGS = os.environ.get('LFLAGS', '').split()
 BLOSC_DIR = os.environ.get('BLOSC_DIR', '')
 
 # Sources & libraries
-inc_dirs = ['bcolz', numpy.get_include()]
+inc_dirs = ['bcolz']
 lib_dirs = []
 libs = []
 def_macros = []
@@ -160,5 +207,6 @@ for binary data.
         test=tests_require
     ),
     packages=find_packages(),
-    package_data={'bcolz': ['carray_ext.pxd']}
+    package_data={'bcolz': ['carray_ext.pxd']},
+    cmdclass=LazyCommandClass(),
 )


### PR DESCRIPTION
Use a lazy cmdclass object to defer accesses to `numpy` and `Cython`
until after those modules have been installed by `setuptools` via
`setup_requires`.

Without this, the fact that we're supplying numpy and Cython in
`setup_requires` is meaningless, because we access numpy at module
scope, well before we're able to tell `setuptools` that we require
numpy.

I built this because I'm trying to remove several hacks and workarounds in the [zipline setup.py](https://github.com/quantopian/zipline/pull/867) to allow users to install zipline without needing to first install numpy.  The linked PR achieves that goal, but we fail installing `bcolz` because it tries to import numpy at module scope.