### PR TITLE
optimisations for carray.__getitem__ with slice and no step

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -7,6 +7,10 @@ Changes from 0.12.1 to 0.12.2
 
 #XXX version-specific blurb XXX#
 
+- Some optimisations have been made within ``carray.__getitem__`` to
+  improve performance when extracting a slice of data from a carray. This
+  is particularly relevant when running some computation chunk-by-chunk over
+  a large carray. (#283 @alimanfoo).
 
 Changes from 0.12.0 to 0.12.1
 =============================


### PR DESCRIPTION
As discussed in #282, these changes remove some overheads when slicing a carray without a step, as is common when computing some result chunk-by-chunk. All tests pass. Profiling data showing the improvement is here: http://nbviewer.ipython.org/gist/alimanfoo/88a937ef0953f4a3c5d1/bcolz_profile_getitem.ipynb