### PR TITLE
BUG: todataframe with columns specified

### DIFF
--- a/bcolz/ctable.py
+++ b/bcolz/ctable.py
@@ -795,10 +795,15 @@ class ctable(object):
         else:
             raise ValueError("you need pandas to use this functionality")
 
+        if orient == 'index':
+            keys = self.names
+        else:
+            keys = self.names if columns is None else columns
+            columns = None
         # Use a generator here to minimize the number of column copies
         # existing simultaneously in-memory
         df = pd.DataFrame.from_items(
-            ((key, self[key][:]) for key in self.names),
+            ((key, self[key][:]) for key in keys),
             columns=columns, orient=orient)
         return df
 

--- a/bcolz/tests/test_ctable.py
+++ b/bcolz/tests/test_ctable.py
@@ -2212,6 +2212,11 @@ class pandasConversionTest(TestCase):
         ct2 = bcolz.ctable.fromdataframe(df)
         for key in ct.names:
             assert_allclose(ct2[key][:], ct[key][:])
+        x = ct.todataframe(columns=['f0', 'f1'])
+        assert_allclose(x, df[['f0', 'f1']])
+        labels = ['l%s' % i for i in xrange(N)]
+        x = ct.todataframe(columns=labels, orient='index')
+        assert_array_equal(x, df.T)
 
     @skipUnless(bcolz.pandas_here, "pandas not here")
     def test01(self):
@@ -2224,6 +2229,11 @@ class pandasConversionTest(TestCase):
         ct2 = bcolz.ctable.fromdataframe(df)
         for i in range(N):
             assert ct2['f2'][i] == ct['f2'][i]
+        x = ct.todataframe(columns=['f0', 'f1'])
+        assert_allclose(x, df[['f0', 'f1']])
+        labels = ['l%s' % i for i in xrange(N)]
+        x = ct.todataframe(columns=labels, orient='index')
+        assert_array_equal(x, df.T)
 
     @skipUnless(bcolz.pandas_here, "pandas not here")
     def test02(self):
@@ -2236,6 +2246,11 @@ class pandasConversionTest(TestCase):
         ct2 = bcolz.ctable.fromdataframe(df)
         for i in range(N):
             assert ct2['f2'][i] == ct['f2'][i]
+        x = ct.todataframe(columns=['f0', 'f1'])
+        assert_allclose(x, df[['f0', 'f1']])
+        labels = ['l%s' % i for i in xrange(N)]
+        x = ct.todataframe(columns=labels, orient='index')
+        assert_array_equal(x, df.T)
 
 
 class pytablesConversionTest(TestCase):


### PR DESCRIPTION
Hello,

In `ctable.todataframe`, when you specify `columns` and `orient='columns'`, pandas checks that the length of the generator is less than the number of columns. However, generators don't have lengths so it crashes. This just limits the generator the requested columns to get around that. 