### PR TITLE
Allow unsigned integer arrays when indexing ctables

### DIFF
--- a/bcolz/ctable.py
+++ b/bcolz/ctable.py
@@ -1252,7 +1252,7 @@ class ctable(object):
         elif hasattr(key, "dtype"):
             if key.dtype.type == np.bool_:
                 return self._where(key)
-            elif np.issubsctype(key, np.int_):
+            elif np.issubsctype(key, np.integer):
                 # An integer array
                 return np.array([tuple(self[i]) for i in key], dtype=self.dtype)
             else:


### PR DESCRIPTION
See issue Blosc/bcolz#351 for description of problem fixed by this
commit.