### PR TITLE
Handling of np.datetime64 and other scalar objects that have __getitem__ attribute in _eval_blocks()

### DIFF
--- a/bcolz/chunked_eval.py
+++ b/bcolz/chunked_eval.py
@@ -243,7 +243,9 @@ def _eval_blocks(expression, vars, vlen, typesize, vm, out_flavor, blen,
                 else:
                     vars_[name] = var[i:i+blen]
             else:
-                if hasattr(var, "__getitem__"):
+                if np.isscalar(var):
+                    vars_[name] = var
+                elif hasattr(var, "__getitem__"):
                     vars_[name] = var[:]
                 else:
                     vars_[name] = var

--- a/bcolz/tests/test_queries.py
+++ b/bcolz/tests/test_queries.py
@@ -312,14 +312,6 @@ class fetchwhereTest(MayBeDiskTest):
     def test06(self):
         """Testing `fetchwhere` method off of a timestamp (pd.datetime64)"""
         N = self.N
-        ra = np.fromiter(((i, i * 2., i * 3)
-                          for i in xrange(N)), dtype='i4,f8,i8')
-        t = bcolz.ctable(ra)
-        ct = t.fetchwhere('f1 < f2')
-        l, s = len(ct), ct['f0'].sum()
-        self.assertEqual(l, N - 1)
-        self.assertEqual(s, (N - 1) * (N / 2))  # Gauss summation formula
-
         query_idx = np.random.randint(0, self.N)
         t = bcolz.fromiter(((i, np.datetime64('2018-03-01') + i) for i in range(N)), dtype="i4,M8[D]", count=N)
         threshold = t[query_idx][1]

--- a/bcolz/tests/test_queries.py
+++ b/bcolz/tests/test_queries.py
@@ -309,6 +309,25 @@ class fetchwhereTest(MayBeDiskTest):
         self.assertEqual(l, N - 1)
         self.assertEqual(s, (N - 1) * (N / 2))  # Gauss summation formula
 
+    def test06(self):
+        """Testing `fetchwhere` method off of a timestamp (pd.datetime64)"""
+        N = self.N
+        ra = np.fromiter(((i, i * 2., i * 3)
+                          for i in xrange(N)), dtype='i4,f8,i8')
+        t = bcolz.ctable(ra)
+        ct = t.fetchwhere('f1 < f2')
+        l, s = len(ct), ct['f0'].sum()
+        self.assertEqual(l, N - 1)
+        self.assertEqual(s, (N - 1) * (N / 2))  # Gauss summation formula
+
+        query_idx = np.random.randint(0, self.N)
+        t = bcolz.fromiter(((i, np.datetime64('2018-03-01') + i) for i in range(N)), dtype="i4,M8[D]", count=N)
+        threshold = t[query_idx][1]
+        result = t.fetchwhere('(f1 > threshold)', user_dict={'threshold': threshold})
+        t_fin = bcolz.fromiter(((i + query_idx, threshold + i) for i in range(1, N - query_idx)), dtype="i4,M8[D]",
+                               count=N)
+        np.testing.assert_array_equal(result[:], t_fin[:])
+
 
 class small_fetchwhereTest(fetchwhereTest, TestCase):
     N = 120


### PR DESCRIPTION
The __eval_blocks() function in chunked_eval.py mishandles np.datetime64 objects since they for some reason have the __getitem__ attribute. This fix should allow users to use ctable.fetchwhere() functions off of datetime queries. 