### PR TITLE
Fix outdated package API usages in Doc tutorial Notebook

### DIFF
--- a/docs/tutorial_carray_memory_profile.ipynb
+++ b/docs/tutorial_carray_memory_profile.ipynb
@@ -255,10 +255,9 @@
     "mw.stop_watching_memory()\n",
     "\n",
     "d = arange_results\n",
-    "print d\n",
+    "print(d)\n",
     "\n",
-    "arange_results_df = pd.DataFrame({'MiB': arange_results.values()}, index=arange_results.keys())\n",
-    "pd.options.display.mpl_style = 'default'\n",
+    "arange_results_df = pd.DataFrame(arange_results.values(), index=arange_results.keys(), columns=['MiB'])\n",
     "arange_results_df.plot(kind='barh', figsize=(9,3), fontsize=16, title=\"arange RAM memory consumption\")"
    ]
   },
@@ -465,10 +464,9 @@
     "%matplotlib inline\n",
     "mw.stop_watching_memory()\n",
     "d = sumif_results\n",
-    "print d\n",
+    "print(d)\n",
     "\n",
-    "sumif_df = pd.DataFrame({'MiB': d.values()}, index=d.keys())\n",
-    "pd.options.display.mpl_style = 'default'\n",
+    "sumif_df = pd.DataFrame(d.values(), index=d.keys(), columns=['MiB'])\n",
     "sumif_df.plot(kind='barh', figsize=(9,3), fontsize=16, title=\"sum-if RAM memory consumption\")"
    ]
   },


### PR DESCRIPTION
This PR fixed following thing:

1. PY2 & PY3 Compatibility: `print d` -> `print(d)`
2. `pd.options.display.mpl_style` is removed from pandas API. Remove this line will just use the default style.
3. In most recent pandas version, `pd.DataFrame({'MiB': arange_results.values()}, index=arange_results.keys())` create a DataFrame contains 1 column with 3 identical tuple as it's values. So I also update this API usage.