### PR TITLE
Fix compatibility issue of xrange func in ctable tutorial notebook.

### DIFF
--- a/docs/tutorial_ctable.ipynb
+++ b/docs/tutorial_ctable.ipynb
@@ -62,6 +62,9 @@
    ],
    "source": [
     "from __future__ import print_function\n",
+    "import sys\n",
+    "if sys.version_info[0] == 2:\n",
+    "    range = xrange\n",
     "\n",
     "import numpy as np\n",
     "import bcolz\n",
@@ -124,7 +127,7 @@
    ],
    "source": [
     "N = int(1e6)\n",
-    "ct = bcolz.fromiter(((i,i*i) for i in xrange(N)), dtype=\"i4,f8\", count=N)\n",
+    "ct = bcolz.fromiter(((i,i*i) for i in range(N)), dtype=\"i4,f8\", count=N)\n",
     "ct"
    ]
   },
@@ -160,7 +163,7 @@
     }
    ],
    "source": [
-    "ct_disk = bcolz.fromiter(((i,i*i) for i in xrange(N)), dtype=\"i4,f8\", count=N, rootdir=\"mydir/ct_disk\")\n",
+    "ct_disk = bcolz.fromiter(((i,i*i) for i in range(N)), dtype=\"i4,f8\", count=N, rootdir=\"mydir/ct_disk\")\n",
     "ct_disk"
    ]
   },
@@ -500,7 +503,7 @@
    },
    "outputs": [],
    "source": [
-    "ct = bcolz.fromiter(((i,i*i) for i in xrange(N)), dtype=\"i4,f8\", count=N)\n",
+    "ct = bcolz.fromiter(((i,i*i) for i in range(N)), dtype=\"i4,f8\", count=N)\n",
     "new_col = np.linspace(0, 1, N)\n",
     "ct.addcol(new_col)"
    ]
@@ -585,7 +588,7 @@
     }
    ],
    "source": [
-    "t = bcolz.fromiter(((i,i*i) for i in xrange(N)), dtype=\"i4,f8\", count=N)\n",
+    "t = bcolz.fromiter(((i,i*i) for i in range(N)), dtype=\"i4,f8\", count=N)\n",
     "[row for row in ct.iter(1,10,3)]"
    ]
   },
@@ -751,7 +754,7 @@
     }
    ],
    "source": [
-    "ct = bcolz.fromiter(((i,i*i) for i in xrange(N)), dtype=\"i4,f8\", count=N)\n",
+    "ct = bcolz.fromiter(((i,i*i) for i in range(N)), dtype=\"i4,f8\", count=N)\n",
     "[row for row in ct.where(\"(f0>0) & (f1<10)\")]"
    ]
   },


### PR DESCRIPTION
Changes made in this PR:

`xrange` is no longer existed in Python 3, to make PY2 & PY3 compatible for running `docs/tutorial_ctable.ipynb`, I made an alias for `xrange` function in PY2:

```python
import sys
if sys.version_info[0] == 2:
    range = xrange
```