### PR TITLE
Documentation fixes for newer sphinx

### DIFF
--- a/bcolz/ctable.py
+++ b/bcolz/ctable.py
@@ -1071,8 +1071,7 @@ class ctable(object):
 
         See Also
         --------
-        See :py:func:`<bcolz.toplevel.iterblocks>` in toplevel functions.
-
+        bcolz.iterblocks
         """
 
         if blen is None:
@@ -1368,8 +1367,7 @@ class ctable(object):
 
         See Also
         --------
-        eval (top level function)
-
+        bcolz.eval
         """
         # Call top-level eval with cols, locals and gloabls as user_dict
         user_dict = kwargs.pop('user_dict', {})

--- a/bcolz/toplevel.py
+++ b/bcolz/toplevel.py
@@ -579,8 +579,7 @@ class cparams(object):
 
     See also
     --------
-    cparams.setdefaults()
-
+    cparams.setdefaults
     """
 
     @property


### PR DESCRIPTION
This fixes a build failure with newer sphinx versions where the entries
in "See Also" sections must adhere to a stricter syntax.